### PR TITLE
Implement track pages and API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ If logged in:
 - Displays all tracks as cards with top 3 lap times, amount of laps, level and type displayed as tags. Sorted by track number.
 - Users can search on any of the displayed information on the card (Even on the names of the top 3 users)
 - Clicking on a track card opens a full page of track data and the full leaderboards
+- Track names are shown as `#05`, `#15`, `#134` (derived from track number and not stored in the database)
 
 ##### Track
 
@@ -120,6 +121,12 @@ Always keep AGENTS.md and README.md updated!
   - `npm run build`: Type-check and production build.
 - Common
   - `cd common`: Used via `file:../common`. If linking breaks, re-run `npm install` in frontend/backend.
+
+## Socket Events
+
+- `getTracks` – list tracks with lap counts and top times.
+- `getTrack` – track details.
+- `getTrackLeaderboard` – best laps per user.
 
 ## Coding Style & Naming Conventions
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains:
 
 - `backend/`: Node.js + TypeScript Socket.IO server. Drizzle + SQLite in `backend/database/`, runtime data in `backend/data/`.
 - `frontend/`: React + Vite app (TypeScript). Entry at `frontend/src/App.tsx`.
+  - Tracks page lists all tracks with search and links to individual leaderboards.
 - `common/`: Shared TypeScript models/utilities, consumed via `file:../common`.
 
 ## Quick Start

--- a/backend/database/database.ts
+++ b/backend/database/database.ts
@@ -1,4 +1,3 @@
-import type { TrackLevel, TrackType } from '@database/schema'
 import * as schema from '@database/schema'
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
@@ -11,26 +10,3 @@ database.pragma('journal_mode = WAL')
 
 const db = drizzle(database, { schema })
 export default db
-
-db.query.tracks.findFirst().then(track => {
-  if (track) return
-  const trackCount = 200
-  const items: (typeof schema.tracks.$inferInsert)[] = []
-
-  const levels: TrackLevel[] = ['white', 'green', 'blue', 'red', 'black']
-  const types: TrackType[] = ['drift', 'valley', 'lagoon', 'stadium']
-
-  for (let i = 0; i < trackCount; i++) {
-    items.push({
-      number: i + 1,
-      level: levels[Math.floor(i / 40) % levels.length]!,
-      type: types[Math.floor(i / 10) % types.length]!,
-    })
-  }
-
-  db.insert(schema.tracks)
-    .values(items)
-    .then(() => {
-      console.log(`Inserted ${trackCount} tracks`)
-    })
-})

--- a/backend/database/schema.ts
+++ b/backend/database/schema.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 import { blob, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import type { TrackLevel, TrackType } from './types'
 
 const common = {
   id: text().primaryKey().$defaultFn(randomUUID),
@@ -24,9 +25,6 @@ export const users = sqliteTable('users', {
     .$default(() => 'user'),
 })
 
-export type TrackLevel = 'white' | 'green' | 'blue' | 'red' | 'black' | 'custom'
-export type TrackType = 'drift' | 'valley' | 'lagoon' | 'stadium'
-
 export const tracks = sqliteTable('tracks', {
   ...common,
   number: integer().notNull(),
@@ -36,6 +34,8 @@ export const tracks = sqliteTable('tracks', {
     .notNull()
     .$default(() => false),
 })
+
+export type { TrackLevel, TrackType }
 
 export const timeEntries = sqliteTable('time_entries', {
   ...common,

--- a/backend/database/types.ts
+++ b/backend/database/types.ts
@@ -1,0 +1,2 @@
+export type TrackLevel = 'white' | 'green' | 'blue' | 'red' | 'black' | 'custom'
+export type TrackType = 'drift' | 'valley' | 'lagoon' | 'stadium'

--- a/backend/src/managers/track.manager.ts
+++ b/backend/src/managers/track.manager.ts
@@ -1,0 +1,144 @@
+import type {
+  TopTime,
+  Track,
+  TrackSummary,
+} from '@chugmania/common/models/track.js'
+import { tryCatchAsync } from '@chugmania/common/utils/try-catch.js'
+import db from '@database/database'
+import {
+  type TrackLevel,
+  type TrackType,
+  timeEntries,
+  tracks,
+  users,
+} from '@database/schema'
+import { asc, count, eq } from 'drizzle-orm'
+
+export default class TrackManager {
+  static async seed(): Promise<void> {
+    const { data, error } = await tryCatchAsync(db.query.tracks.findFirst())
+    if (error) throw error
+    if (data) return
+
+    const trackCount = 200
+    const levels: TrackLevel[] = ['white', 'green', 'blue', 'red', 'black']
+    const types: TrackType[] = ['drift', 'valley', 'lagoon', 'stadium']
+    const items: (typeof tracks.$inferInsert)[] = []
+    for (let i = 0; i < trackCount; i++) {
+      items.push({
+        number: i + 1,
+        level: levels[Math.floor(i / 40) % levels.length]!,
+        type: types[Math.floor(i / 10) % types.length]!,
+      })
+    }
+    await db.insert(tracks).values(items)
+    console.log(`Inserted ${trackCount} tracks`)
+  }
+
+  private static async buildSummary(
+    t: typeof tracks.$inferSelect
+  ): Promise<TrackSummary> {
+    const topQuery = db
+      .select({
+        duration: timeEntries.duration,
+        userId: timeEntries.user,
+        userName: users.name,
+      })
+      .from(timeEntries)
+      .leftJoin(users, eq(users.id, timeEntries.user))
+      .where(eq(timeEntries.track, t.id))
+      .orderBy(asc(timeEntries.duration))
+      .limit(3)
+
+    const countQuery = db
+      .select({ value: count() })
+      .from(timeEntries)
+      .where(eq(timeEntries.track, t.id))
+
+    const [
+      { data: topRows, error: topError },
+      { data: countRows, error: countError },
+    ] = await Promise.all([tryCatchAsync(topQuery), tryCatchAsync(countQuery)])
+
+    if (topError) throw topError
+    if (countError) throw countError
+
+    const topTimes: TopTime[] = (topRows ?? []).map(r => ({
+      user: { id: r.userId, name: r.userName ?? '' },
+      duration: r.duration,
+    }))
+
+    const lapCount = countRows?.[0]?.value ?? 0
+
+    return {
+      id: t.id,
+      number: t.number,
+      level: t.level,
+      type: t.type,
+      lapCount,
+      topTimes,
+    }
+  }
+
+  static async getTracks(): Promise<TrackSummary[]> {
+    const { data, error } = await tryCatchAsync(
+      db.select().from(tracks).orderBy(asc(tracks.number))
+    )
+
+    if (error) throw error
+    const rows = data ?? []
+    const summaries: TrackSummary[] = []
+    for (const t of rows) {
+      summaries.push(await this.buildSummary(t))
+    }
+    return summaries
+  }
+
+  static async getTrack(id: string): Promise<Track> {
+    const { data, error } = await tryCatchAsync(
+      db.query.tracks.findFirst({ where: eq(tracks.id, id) })
+    )
+
+    if (error) throw error
+    if (!data) throw Error(`Couldn't find track with id ${id}`)
+
+    return this.buildSummary(data)
+  }
+
+  static async getLeaderboard(
+    id: string,
+    offset = 0,
+    limit = 100
+  ): Promise<TopTime[]> {
+    const { data, error } = await tryCatchAsync(
+      db
+        .select({
+          duration: timeEntries.duration,
+          userId: timeEntries.user,
+          userName: users.name,
+        })
+        .from(timeEntries)
+        .leftJoin(users, eq(users.id, timeEntries.user))
+        .where(eq(timeEntries.track, id))
+    )
+
+    if (error) throw error
+
+    const rows = data ?? []
+    const best = new Map<string, TopTime>()
+    for (const r of rows) {
+      const existing = best.get(r.userId)
+      if (!existing || r.duration < existing.duration) {
+        best.set(r.userId, {
+          user: { id: r.userId, name: r.userName ?? '' },
+          duration: r.duration,
+        })
+      }
+    }
+
+    const sorted = Array.from(best.values()).sort(
+      (a, b) => a.duration - b.duration
+    )
+    return sorted.slice(offset, offset + limit)
+  }
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,16 +1,32 @@
 import {
   WS_CONNECT_NAME,
   WS_DISCONNECT_NAME,
+  WS_GET_LEADERBOARD_NAME,
+  WS_GET_TRACKS_NAME,
+  WS_GET_TRACK_NAME,
   WS_LOGIN_NAME,
   WS_REGISTER_NAME,
 } from '@chugmania/common/models/constants.js'
+import type {
+  GetTrackDetailsRequest,
+  GetTrackLeaderboardRequest,
+} from '@chugmania/common/models/requests.js'
 import type { ErrorResponse } from '@chugmania/common/models/responses.js'
+import { createServer } from 'http'
 import { Server } from 'socket.io'
 import AuthManager from './managers/auth.manager'
 import ConnectionManager from './managers/connection.manager'
+import TrackManager from './managers/track.manager'
 
 const port = 6996
-const io = new Server(port, { cors: { origin: '*' } })
+const httpServer = createServer((_req, res) => {
+  res.statusCode = 404
+  res.end()
+})
+
+const io = new Server(httpServer, { cors: { origin: '*' } })
+
+await TrackManager.seed()
 
 io.on(WS_CONNECT_NAME, s =>
   ConnectionManager.connect(s).then(() => {
@@ -28,6 +44,27 @@ io.on(WS_CONNECT_NAME, s =>
         )
         .then(c)
     )
+    s.on(WS_GET_TRACKS_NAME, (_, c) =>
+      TrackManager.getTracks()
+        .then(tracks => c({ tracks }))
+        .catch(err =>
+          c({ success: false, message: err.message } satisfies ErrorResponse)
+        )
+    )
+    s.on(WS_GET_TRACK_NAME, (arg: GetTrackDetailsRequest, c) =>
+      TrackManager.getTrack(arg.id)
+        .then(track => c(track))
+        .catch(err =>
+          c({ success: false, message: err.message } satisfies ErrorResponse)
+        )
+    )
+    s.on(WS_GET_LEADERBOARD_NAME, (arg: GetTrackLeaderboardRequest, c) =>
+      TrackManager.getLeaderboard(arg.id, arg.offset, arg.limit)
+        .then(times => c({ times }))
+        .catch(err =>
+          c({ success: false, message: err.message } satisfies ErrorResponse)
+        )
+    )
     s.on(WS_DISCONNECT_NAME, () => ConnectionManager.disconnect(s))
   })
 )
@@ -37,3 +74,5 @@ io.use((socket, next) => {
     .catch(next)
     .then(() => next())
 })
+
+httpServer.listen(port)

--- a/common/models/constants.ts
+++ b/common/models/constants.ts
@@ -2,5 +2,8 @@ export const WS_CONNECT_NAME = 'connect'
 export const WS_DISCONNECT_NAME = 'disconnect'
 export const WS_LOGIN_NAME = 'login'
 export const WS_REGISTER_NAME = 'register'
+export const WS_GET_TRACKS_NAME = 'getTracks'
+export const WS_GET_TRACK_NAME = 'getTrack'
+export const WS_GET_LEADERBOARD_NAME = 'getTrackLeaderboard'
 
 export const AUTH_KEY = 'auth'

--- a/common/models/requests.ts
+++ b/common/models/requests.ts
@@ -17,3 +17,19 @@ export function isRegisterRequest(data: any): data is RegisterRequest {
   if (typeof data !== 'object') return false
   return data.email && data.password && data.name
 }
+
+export type GetTracksRequest = {
+  offset?: number
+  limit?: number
+}
+
+export type GetTrackDetailsRequest = {
+  id: string
+}
+
+export type GetTrackLeaderboardRequest = {
+  id: string
+  offset?: number
+  limit?: number
+}
+

--- a/common/models/responses.ts
+++ b/common/models/responses.ts
@@ -1,3 +1,5 @@
+import type { TopTime, Track, TrackSummary } from './track'
+
 export type BackendResponse = LoginSuccessResponse | RegisterSuccessResponse | ErrorResponse
 
 export type LoginSuccessResponse = {
@@ -31,3 +33,8 @@ export function isErrorResponse(data: any): data is ErrorResponse {
   if (typeof data !== 'object') return false
   return data.success === false && data.message
 }
+
+export type GetTracksResponse = { tracks: TrackSummary[] }
+export type GetTrackDetailsResponse = Track
+export type GetTrackLeaderboardResponse = { times: TopTime[] }
+

--- a/common/models/track.ts
+++ b/common/models/track.ts
@@ -1,0 +1,21 @@
+import type { TrackLevel, TrackType } from '@database/types'
+export type { TrackLevel, TrackType }
+
+export type TopTime = {
+  user: {
+    id: string
+    name: string
+  }
+  duration: number
+}
+
+export type TrackSummary = {
+  id: string
+  number: number
+  level: TrackLevel
+  type: TrackType
+  lapCount: number
+  topTimes: TopTime[]
+}
+
+export type Track = TrackSummary

--- a/common/utils/time.ts
+++ b/common/utils/time.ts
@@ -1,0 +1,6 @@
+export function formatTime(ms: number): string {
+  const minutes = Math.floor(ms / 60000)
+  const seconds = Math.floor((ms % 60000) / 1000)
+  const hundredths = Math.floor((ms % 1000) / 10)
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}.${String(hundredths).padStart(2, '0')}`
+}

--- a/common/utils/track.ts
+++ b/common/utils/track.ts
@@ -1,0 +1,3 @@
+export function formatTrackName(num: number): string {
+  return `#${String(num).padStart(2, '0')}`
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Home from './app/pages/Home'
 import Login from './app/pages/Login'
 import Players from './app/pages/Players'
 import Tracks from './app/pages/Tracks'
+import Track from './app/pages/Track'
 import { AuthProvider } from './contexts/AuthContext'
 import { ConnectionProvider } from './contexts/ConnectionContext'
 
@@ -21,6 +22,7 @@ createRoot(document.getElementById('root')!).render(
             <Route element={<Layout />}>
               <Route index element={<Home />} />
               <Route path='tracks' element={<Tracks />} />
+              <Route path='tracks/:id' element={<Track />} />
               <Route path='players' element={<Players />} />
               <Route path='login' element={<Login />} />
             </Route>

--- a/frontend/src/app/components/TrackCard.tsx
+++ b/frontend/src/app/components/TrackCard.tsx
@@ -1,0 +1,32 @@
+import type { TrackSummary } from '@chugmania/common/models/track.js'
+import { formatTime } from '@chugmania/common/utils/time.js'
+import { formatTrackName } from '@chugmania/common/utils/track.js'
+import { Link } from 'react-router-dom'
+
+export default function TrackCard({ track }: { track: TrackSummary }) {
+  return (
+    <Link
+      to={`/tracks/${track.id}`}
+      className='block rounded-lg border border-white/10 bg-white/5 p-4 hover:border-white/20 hover:bg-white/10'
+    >
+      <h3 className='font-f1-black text-accent mb-2 text-xl uppercase tracking-wider'>
+        {formatTrackName(track.number)}
+      </h3>
+      <div className='mb-2 text-sm text-slate-200'>
+        {track.topTimes.map((t, i) => (
+          <div key={t.user.id} className='flex justify-between'>
+            <span>
+              {i + 1}. {t.user.name}
+            </span>
+            <span>{formatTime(t.duration)}</span>
+          </div>
+        ))}
+      </div>
+      <div className='flex gap-2 text-xs uppercase tracking-wider text-slate-300'>
+        <span className='rounded bg-white/10 px-2 py-0.5'>{track.level}</span>
+        <span className='rounded bg-white/10 px-2 py-0.5'>{track.type}</span>
+        <span className='ml-auto'>{track.lapCount} laps</span>
+      </div>
+    </Link>
+  )
+}

--- a/frontend/src/app/pages/Track.tsx
+++ b/frontend/src/app/pages/Track.tsx
@@ -1,0 +1,97 @@
+import {
+  WS_GET_LEADERBOARD_NAME,
+  WS_GET_TRACK_NAME,
+} from '@chugmania/common/models/constants.js'
+import type { TopTime, Track } from '@chugmania/common/models/track.js'
+import { formatTrackName } from '@chugmania/common/utils/track.js'
+import { formatTime } from '@chugmania/common/utils/time.js'
+import {
+  isErrorResponse,
+  type ErrorResponse,
+  type GetTrackLeaderboardResponse,
+} from '@chugmania/common/models/responses.js'
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { useConnection } from '../../contexts/ConnectionContext'
+
+export default function Track() {
+  const { id } = useParams()
+  const [track, setTrack] = useState<Track | null>(null)
+  const [leaderboard, setLeaderboard] = useState<TopTime[]>([])
+  const [search, setSearch] = useState('')
+  const [gapMode, setGapMode] = useState<'leader' | 'previous'>('leader')
+  const { socket } = useConnection()
+
+  useEffect(() => {
+    if (!id) return
+    socket.emit(
+      WS_GET_TRACK_NAME,
+      { id },
+      (d: Track | ErrorResponse) => {
+        if (isErrorResponse(d)) console.error(d.message)
+        else setTrack(d)
+      }
+    )
+    socket.emit(
+      WS_GET_LEADERBOARD_NAME,
+      { id },
+      (d: GetTrackLeaderboardResponse | ErrorResponse) => {
+        if (isErrorResponse(d)) console.error(d.message)
+        else setLeaderboard(d.times ?? [])
+      }
+    )
+  }, [id, socket])
+
+  const term = search.toLowerCase()
+  const filtered = leaderboard.map((t, i) => {
+    const dim = term ? !t.user.name.toLowerCase().includes(term) : false
+    let gap = 0
+    if (gapMode === 'leader') gap = t.duration - leaderboard[0]?.duration
+    else if (i > 0) gap = t.duration - leaderboard[i - 1]!.duration
+    return { ...t, dim, gap }
+  })
+
+  return track ? (
+    <div className='space-y-4'>
+      <h2 className='font-f1-black text-accent text-2xl uppercase tracking-wider'>
+        {formatTrackName(track.number)}
+      </h2>
+      <div className='flex gap-2'>
+        <input
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder='Search player'
+          className='flex-1 rounded-md border border-white/10 bg-white/5 p-2'
+        />
+        <button
+          onClick={() =>
+            setGapMode(gapMode === 'leader' ? 'previous' : 'leader')
+          }
+          className='rounded-md border border-white/10 bg-white/5 px-4'
+        >
+          Gap: {gapMode}
+        </button>
+      </div>
+      <ul className='space-y-1'>
+        {filtered.map((t, i) => (
+          <li
+            key={t.user.id}
+            className={`${t.dim ? 'opacity-40' : ''} flex justify-between`}
+          >
+            <span>
+              {i + 1}. {t.user.name}
+            </span>
+            <span className='flex gap-2'>
+              {formatTime(t.duration)}
+              {i > 0 && (
+                <span className='rounded bg-white/10 px-1 text-xs'>
+                  +{formatTime(t.gap)}
+                </span>
+              )}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  ) : null
+}

--- a/frontend/src/app/pages/Tracks.tsx
+++ b/frontend/src/app/pages/Tracks.tsx
@@ -1,3 +1,67 @@
+import {
+  WS_GET_TRACKS_NAME,
+} from '@chugmania/common/models/constants.js'
+import type { TrackSummary } from '@chugmania/common/models/track.js'
+import { formatTrackName } from '@chugmania/common/utils/track.js'
+import {
+  isErrorResponse,
+  type ErrorResponse,
+  type GetTracksResponse,
+} from '@chugmania/common/models/responses.js'
+import { useEffect, useState } from 'react'
+import { useConnection } from '../../contexts/ConnectionContext'
+import TrackCard from '../components/TrackCard'
+
 export default function Tracks() {
-  return null
+  const [tracks, setTracks] = useState<TrackSummary[]>([])
+  const [search, setSearch] = useState('')
+  const [loading, setLoading] = useState(true)
+  const { socket } = useConnection()
+
+  useEffect(() => {
+    socket.emit(
+      WS_GET_TRACKS_NAME,
+      undefined,
+      (d: GetTracksResponse | ErrorResponse) => {
+        if (isErrorResponse(d)) {
+          console.error(d.message)
+          window.alert('Failed to load tracks')
+        } else {
+          setTracks(d.tracks ?? [])
+        }
+        setLoading(false)
+      }
+    )
+  }, [socket])
+
+  const term = search.toLowerCase()
+  const filtered = tracks.filter(t => {
+    return (
+      t.number.toString().includes(term) ||
+      formatTrackName(t.number).toLowerCase().includes(term) ||
+      t.level.toLowerCase().includes(term) ||
+      t.type.toLowerCase().includes(term) ||
+      t.topTimes.some(tt => tt.user.name.toLowerCase().includes(term))
+    )
+  })
+
+  return (
+    <div className='space-y-4'>
+      <input
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+        placeholder='Search tracks'
+        className='w-full rounded-md border border-white/10 bg-white/5 p-2'
+      />
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3'>
+          {filtered.map(t => (
+            <TrackCard key={t.id} track={t} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
 }

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -21,7 +21,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@database/*": ["../backend/database/*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- derive track names from numbers and remove stored track name
- move track seeding into manager and run at server startup
- share track/time formatting utilities across frontend

## Testing
- `cd backend && npm run check`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba043fca4c8329b3e1abea1a0e9de4