### PR TITLE
Frontend data reactivity redesign

### DIFF
--- a/common/models/socket.io.ts
+++ b/common/models/socket.io.ts
@@ -36,18 +36,33 @@ export type ErrorResponse = {
   message: string
 }
 
+export type Resource = 'sessions' | 'time_entries' | 'tracks' | 'users'
+
+export type DataAction = 'create' | 'update' | 'delete'
+
+export interface ResourceUpdate<T = any> {
+  resource: Resource
+  action: DataAction
+  id: string
+  data?: T
+}
+
 export interface ServerToClientEvents {
   user_data: (r: EventRes<'get_user_data'>) => void
   all_users: (r: UserInfo[]) => void
   all_tracks: (r: Track[]) => void
   all_time_entries: (r: TimeEntry[]) => void
   all_sessions: (r: SessionWithSignups[]) => void
+  resource_initial_data: (resource: Resource, data: any[]) => void
+  resource_updated: (update: ResourceUpdate) => void
 }
 
 export interface ClientToServerEvents {
   connect: () => void
   disconnect: () => void
   connect_error: (err: Error) => void
+  subscribe: (resources: Resource[]) => void
+  unsubscribe: (resources: Resource[]) => void
   login: (
     r: LoginRequest,
     callback: (r: LoginResponse | ErrorResponse) => void

--- a/frontend/app/pages/SessionPage.tsx
+++ b/frontend/app/pages/SessionPage.tsx
@@ -33,7 +33,7 @@ import { Spinner } from '@/components/ui/spinner'
 import UserRow from '@/components/user/UserRow'
 import { useAuth } from '@/contexts/AuthContext'
 import { useConnection } from '@/contexts/ConnectionContext'
-import { useData } from '@/contexts/DataContext'
+import { useData, useDataSubscription } from '@/contexts/DataContext'
 import loc from '@/lib/locales'
 import type { SessionWithSignups } from '@common/models/session'
 import { isUpcoming } from '@common/utils/date'
@@ -152,6 +152,7 @@ function Signup({
 export default function SessionPage() {
   const { id } = useParams()
   const { socket } = useConnection()
+  useDataSubscription(['sessions', 'tracks', 'timeEntries'])
   const { sessions, tracks, isLoadingData } = useData()
   const { loggedInUser, isLoggedIn, isLoading } = useAuth()
   const [editDialogOpen, setEditDialogOpen] = useState(false)

--- a/frontend/app/pages/SessionsPage.tsx
+++ b/frontend/app/pages/SessionsPage.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/breadcrumb'
 import { Button } from '@/components/ui/button'
 import { useAuth } from '@/contexts/AuthContext'
-import { useData } from '@/contexts/DataContext'
+import { useData, useDataSubscription } from '@/contexts/DataContext'
 import loc from '@/lib/locales'
 import { isOngoing, isPast, isUpcoming } from '@common/utils/date'
 import { CalendarIcon } from '@heroicons/react/24/solid'
@@ -43,6 +43,7 @@ export function SessionsContent({
   showLink,
   ...props
 }: Readonly<{ showLink?: boolean } & ComponentProps<'div'>>) {
+  useDataSubscription(['sessions'])
   const { loggedInUser, isLoggedIn } = useAuth()
   const { sessions } = useData()
 

--- a/frontend/app/pages/TrackPage.tsx
+++ b/frontend/app/pages/TrackPage.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/breadcrumb'
 import { Spinner } from '@/components/ui/spinner'
 import { useAuth } from '@/contexts/AuthContext'
-import { useData } from '@/contexts/DataContext'
+import { useData, useDataSubscription } from '@/contexts/DataContext'
 import loc from '@/lib/locales'
 import { formatTrackName } from '@common/utils/track'
 import { useParams } from 'react-router-dom'
@@ -18,6 +18,7 @@ import { useParams } from 'react-router-dom'
 export default function TrackPage() {
   const { id } = useParams()
   const { isLoggedIn, loggedInUser } = useAuth()
+  useDataSubscription(['tracks', 'timeEntries'])
   const { timeEntries, tracks, isLoadingData } = useData()
 
   if (isLoadingData) {

--- a/frontend/app/pages/TracksPage.tsx
+++ b/frontend/app/pages/TracksPage.tsx
@@ -10,7 +10,7 @@ import {
 import { Empty } from '@/components/ui/empty'
 import { Item, ItemContent, ItemMedia } from '@/components/ui/item'
 import { Skeleton } from '@/components/ui/skeleton'
-import { useData } from '@/contexts/DataContext'
+import { useData, useDataSubscription } from '@/contexts/DataContext'
 import loc from '@/lib/locales'
 import type { Track } from '@common/models/track'
 import type { ComponentProps } from 'react'
@@ -63,6 +63,7 @@ export function TracksContent({
   className,
   showLink,
 }: Readonly<TracksPageProps>) {
+  useDataSubscription(['tracks', 'timeEntries'])
   const { tracks, timeEntries, isLoadingData } = useData()
 
   if (isLoadingData) {

--- a/frontend/app/pages/UserPage.tsx
+++ b/frontend/app/pages/UserPage.tsx
@@ -9,13 +9,14 @@ import {
 } from '@/components/ui/breadcrumb'
 import { Spinner } from '@/components/ui/spinner'
 import UserCard from '@/components/user/UserCard'
-import { useData } from '@/contexts/DataContext'
+import { useData, useDataSubscription } from '@/contexts/DataContext'
 import loc from '@/lib/locales'
 import { getUserFullName } from '@common/models/user'
 import { useParams } from 'react-router-dom'
 
 export default function UserPage() {
   const { id } = useParams()
+  useDataSubscription(['users', 'tracks', 'timeEntries'])
   const { users, tracks, isLoadingData } = useData()
 
   if (isLoadingData) {

--- a/frontend/app/pages/UsersPage.tsx
+++ b/frontend/app/pages/UsersPage.tsx
@@ -23,7 +23,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import UserForm from '@/components/user/UserForm'
 import UserRow from '@/components/user/UserRow'
 import { useAuth } from '@/contexts/AuthContext'
-import { useData } from '@/contexts/DataContext'
+import { useData, useDataSubscription } from '@/contexts/DataContext'
 import loc from '@/lib/locales'
 import type { UserInfo } from '@common/models/user'
 import { PlusIcon } from '@heroicons/react/24/solid'
@@ -81,6 +81,7 @@ export function UsersContent({
   showAll,
   showLink,
 }: Readonly<UsersPageProps>) {
+  useDataSubscription(['users'])
   const { users: ud } = useData()
   const { isLoggedIn, loggedInUser, isLoading } = useAuth()
   const isModerator = isLoggedIn && loggedInUser.role !== 'user'

--- a/frontend/contexts/DataContext.tsx
+++ b/frontend/contexts/DataContext.tsx
@@ -1,32 +1,33 @@
 import type { SessionWithSignups } from '@common/models/session'
+import type {
+  DataAction,
+  Resource,
+  ResourceUpdate,
+} from '@common/models/socket.io'
 import type { TimeEntry } from '@common/models/timeEntry'
 import type { Track } from '@common/models/track'
 import type { UserInfo } from '@common/models/user'
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react'
 import { useConnection } from './ConnectionContext'
 
-type DataContextType =
-  | {
-      isLoadingData: false
-      tracks: Track[]
-      timeEntries: TimeEntry[]
-      users: UserInfo[]
-      sessions: SessionWithSignups[]
-    }
-  | {
-      isLoadingData: true
-      tracks?: never
-      timeEntries?: never
-      users?: never
-      sessions?: never
-    }
+type DataContextType = {
+  isLoadingData: boolean
+  tracks: Track[]
+  timeEntries: TimeEntry[]
+  users: UserInfo[]
+  sessions: SessionWithSignups[]
+  subscribe: (resources: Resource[]) => void
+  unsubscribe: (resources: Resource[]) => void
+}
 
 const DataContext = createContext<DataContextType | undefined>(undefined)
 
@@ -58,58 +59,110 @@ export function parseDatesArray<T extends Record<string, any>>(arr: T[]): T[] {
   return arr.map(parseDates)
 }
 
+function handleUpdate<T extends { id: string }>(
+  prev: T[],
+  action: DataAction,
+  id: string,
+  data?: any
+): T[] {
+  if (action === 'create') return [...prev, parseDates(data)]
+  if (action === 'update')
+    return prev.map(item => (item.id === id ? parseDates(data) : item))
+  if (action === 'delete') return prev.filter(item => item.id !== id)
+  return prev
+}
+
 export function DataProvider({ children }: Readonly<{ children: ReactNode }>) {
   const { socket } = useConnection()
 
-  const [tracks, setTracks] = useState<DataContextType['tracks']>(undefined)
-  const [timeEntries, setTimeEntries] =
-    useState<DataContextType['timeEntries']>(undefined)
-  const [users, setUsers] = useState<DataContextType['users']>(undefined)
-  const [sessions, setSessions] =
-    useState<DataContextType['sessions']>(undefined)
+  const [tracks, setTracks] = useState<Track[]>([])
+  const [timeEntries, setTimeEntries] = useState<TimeEntry[]>([])
+  const [users, setUsers] = useState<UserInfo[]>([])
+  const [sessions, setSessions] = useState<SessionWithSignups[]>([])
+
+  const subCounts = useRef<Record<Resource, number>>({
+    sessions: 0,
+    time_entries: 0,
+    tracks: 0,
+    users: 0,
+  })
+
+  const subscribe = useCallback(
+    (resources: Resource[]) => {
+      const toSubscribe: Resource[] = []
+      resources.forEach(r => {
+        subCounts.current[r]++
+        if (subCounts.current[r] === 1) {
+          toSubscribe.push(r)
+        }
+      })
+      if (toSubscribe.length > 0) {
+        socket.emit('subscribe', toSubscribe)
+      }
+    },
+    [socket]
+  )
+
+  const unsubscribe = useCallback(
+    (resources: Resource[]) => {
+      const toUnsubscribe: Resource[] = []
+      resources.forEach(r => {
+        subCounts.current[r]--
+        if (subCounts.current[r] <= 0) {
+          subCounts.current[r] = 0 // Safety
+          toUnsubscribe.push(r)
+          // Clear data
+          if (r === 'sessions') setSessions([])
+          if (r === 'tracks') setTracks([])
+          if (r === 'time_entries') setTimeEntries([])
+          if (r === 'users') setUsers([])
+        }
+      })
+      if (toUnsubscribe.length > 0) {
+        socket.emit('unsubscribe', toUnsubscribe)
+      }
+    },
+    [socket]
+  )
 
   useEffect(() => {
-    socket.on('all_sessions', data => {
-      setSessions(parseDatesArray(data))
+    socket.on('resource_initial_data', (resource, data) => {
+      const parsed = parseDatesArray(data)
+      if (resource === 'sessions') setSessions(parsed)
+      if (resource === 'tracks') setTracks(parsed)
+      if (resource === 'time_entries') setTimeEntries(parsed)
+      if (resource === 'users') setUsers(parsed)
     })
 
-    socket.on('all_time_entries', data => {
-      setTimeEntries(parseDatesArray(data))
-    })
-
-    socket.on('all_tracks', data => {
-      setTracks(parseDatesArray(data))
-    })
-
-    socket.on('all_users', data => {
-      setUsers(parseDatesArray(data))
+    socket.on('resource_updated', (update: ResourceUpdate) => {
+      const { resource, action, id, data } = update
+      if (resource === 'sessions')
+        setSessions(prev => handleUpdate(prev, action, id, data))
+      if (resource === 'tracks')
+        setTracks(prev => handleUpdate(prev, action, id, data))
+      if (resource === 'time_entries')
+        setTimeEntries(prev => handleUpdate(prev, action, id, data))
+      if (resource === 'users')
+        setUsers(prev => handleUpdate(prev, action, id, data))
     })
 
     return () => {
-      socket.off('all_sessions')
-      socket.off('all_time_entries')
-      socket.off('all_tracks')
-      socket.off('all_users')
+      socket.off('resource_initial_data')
+      socket.off('resource_updated')
     }
-  }, [])
+  }, [socket])
 
   const context = useMemo<DataContextType>(() => {
-    if (
-      tracks === undefined ||
-      timeEntries === undefined ||
-      users === undefined ||
-      sessions === undefined
-    ) {
-      return { isLoadingData: true }
-    }
     return {
       isLoadingData: false,
       timeEntries,
       sessions,
       tracks,
       users,
+      subscribe,
+      unsubscribe,
     }
-  }, [tracks, timeEntries, users, sessions])
+  }, [tracks, timeEntries, users, sessions, subscribe, unsubscribe])
 
   return <DataContext.Provider value={context}>{children}</DataContext.Provider>
 }
@@ -118,4 +171,12 @@ export const useData = () => {
   const context = useContext(DataContext)
   if (!context) throw new Error('useData must be used inside DataProvider')
   return context
+}
+
+export const useDataSubscription = (resources: Resource[]) => {
+  const { subscribe, unsubscribe } = useData()
+  useEffect(() => {
+    subscribe(resources)
+    return () => unsubscribe(resources)
+  }, [JSON.stringify(resources), subscribe, unsubscribe])
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2933,7 +2932,6 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3068,7 +3066,6 @@
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3079,7 +3076,6 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3261,7 +3257,6 @@
       "integrity": "sha512-gaYt9yqTbQ1iOxLpJA8FPR5PiaHP+jlg8I5EX0Rs2KFwNzhBsF40KzMZS5FwelY7RG0wzaucWdqSAJM3uNCPCg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -3344,7 +3339,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -4129,7 +4123,6 @@
       "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5573,7 +5566,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5623,7 +5615,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5708,7 +5699,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5725,7 +5715,6 @@
       "integrity": "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "prettier": ">=2.0",
         "typescript": ">=2.9",
@@ -5922,7 +5911,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5953,7 +5941,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6807,8 +6794,7 @@
       "version": "4.1.16",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.16.tgz",
       "integrity": "sha512-pONL5awpaQX4LN5eiv7moSiSPd/DLDzKVRJz8Q9PgzmAdd1R4307GQS2ZpfiN7ZmekdQrfhZZiSE5jkLR4WNaA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-safe-area": {
       "version": "1.1.0",
@@ -7047,7 +7033,6 @@
       "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -7116,7 +7101,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7255,7 +7239,6 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
Implement a subscription-based data reactivity model to reduce bandwidth and improve performance by only broadcasting changed data and fetching data when necessary.

This PR refactors the system to use a Socket.IO subscription model where the frontend explicitly subscribes to specific data resources (e.g., 'users', 'sessions'). The backend then sends initial data for these resources and subsequently sends only granular create, update, or delete events for individual items, significantly reducing network traffic and improving client-side data management.

---
<a href="https://cursor.com/background-agent?bcId=bc-45ec77cf-f12e-4c04-b7a3-b72577fb3e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45ec77cf-f12e-4c04-b7a3-b72577fb3e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

