### PR TITLE
feat(sessions): admin and moderator session participant management

### DIFF
--- a/backend/src/managers/session.manager.ts
+++ b/backend/src/managers/session.manager.ts
@@ -2,6 +2,7 @@ import {
   isCreateSessionRequest,
   isDeleteSessionRequest,
   isEditSessionRequest,
+  isRemoveSessionSignupRequest,
   isRsvpSessionRequest,
   type SessionSignup,
   type SessionWithSignups,
@@ -221,6 +222,61 @@ export default class SessionManager {
       socket.id,
       `Signed up for session with response: ${requestData.response}`,
       session.id
+    )
+
+    broadcast('all_sessions', await SessionManager.getAllSessions())
+    await SessionScheduler.reschedule()
+
+    return { success: true }
+  }
+
+  static async onRemoveSessionSignup(
+    socket: TypedSocket,
+    request: EventReq<'remove_session_signup'>
+  ): Promise<EventRes<'remove_session_signup'>> {
+    if (!isRemoveSessionSignupRequest(request)) {
+      throw new Error(
+        loc.no.error.messages.invalid_request('RemoveSessionSignupRequest')
+      )
+    }
+
+    await AuthManager.checkAuth(socket, ['admin', 'moderator'])
+
+    const { type, ...requestData } = request
+
+    const session = await db.query.sessions.findFirst({
+      where: and(
+        eq(sessions.id, requestData.session),
+        isNull(sessions.deletedAt)
+      ),
+    })
+
+    if (!session) {
+      throw new Error(loc.no.error.messages.not_in_db(requestData.session))
+    }
+
+    const signup = await db.query.sessionSignups.findFirst({
+      where: and(
+        eq(sessionSignups.session, requestData.session),
+        eq(sessionSignups.user, requestData.user),
+        isNull(sessionSignups.deletedAt)
+      ),
+    })
+
+    if (!signup) {
+      throw new Error(loc.no.session.errorMessages.no_signup_to_remove)
+    }
+
+    await db
+      .update(sessionSignups)
+      .set({ deletedAt: new Date() })
+      .where(eq(sessionSignups.id, signup.id))
+
+    console.debug(
+      new Date().toISOString(),
+      socket.id,
+      'Removed session signup',
+      signup.id
     )
 
     broadcast('all_sessions', await SessionManager.getAllSessions())

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -91,6 +91,7 @@ async function Connect(s: TypedSocket) {
   setup(s, 'create_session', SessionManager.onCreateSession)
   setup(s, 'edit_session', SessionManager.onEditSession)
   setup(s, 'rsvp_session', SessionManager.onRsvpSession)
+  setup(s, 'remove_session_signup', SessionManager.onRemoveSessionSignup)
   setup(s, 'delete_session', SessionManager.onDeleteSession)
 
   setup(s, 'create_match', MatchManager.onCreateMatch)

--- a/common/models/session.ts
+++ b/common/models/session.ts
@@ -66,3 +66,20 @@ export function isDeleteSessionRequest(
   if (typeof data !== 'object' || data === null) return false
   return data.type === 'DeleteSessionRequest' && typeof data.id === 'string'
 }
+
+export type RemoveSessionSignupRequest = {
+  type: 'RemoveSessionSignupRequest'
+  session: Session['id']
+  user: UserInfo['id']
+}
+
+export function isRemoveSessionSignupRequest(
+  data: any
+): data is RemoveSessionSignupRequest {
+  if (typeof data !== 'object' || data === null) return false
+  return (
+    data.type === 'RemoveSessionSignupRequest' &&
+    typeof data.session === 'string' &&
+    typeof data.user === 'string'
+  )
+}

--- a/common/models/socket.io.ts
+++ b/common/models/socket.io.ts
@@ -15,6 +15,7 @@ import type {
   CreateSessionRequest,
   DeleteSessionRequest,
   EditSessionRequest,
+  RemoveSessionSignupRequest,
   RsvpSessionRequest,
   SessionWithSignups,
 } from './session'
@@ -102,6 +103,10 @@ export interface ClientToServerEvents {
   ) => void
   rsvp_session: (
     r: RsvpSessionRequest,
+    callback: (r: SuccessResponse | ErrorResponse) => void
+  ) => void
+  remove_session_signup: (
+    r: RemoveSessionSignupRequest,
     callback: (r: SuccessResponse | ErrorResponse) => void
   ) => void
   delete_session: (

--- a/frontend/app/pages/SessionPage.tsx
+++ b/frontend/app/pages/SessionPage.tsx
@@ -1,3 +1,4 @@
+import Combobox from '@/components/combobox'
 import ConfirmationButton from '@/components/ConfirmationButton'
 import { PageSubheader } from '@/components/PageHeader'
 import SessionCard from '@/components/session/SessionCard'
@@ -23,6 +24,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { Empty } from '@/components/ui/empty'
+import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
@@ -36,7 +38,9 @@ import { useAuth } from '@/contexts/AuthContext'
 import { useConnection } from '@/contexts/ConnectionContext'
 import { useData } from '@/contexts/DataContext'
 import loc from '@/lib/locales'
+import { userToLookupItem } from '@/lib/lookup-utils'
 import type { SessionWithSignups } from '@common/models/session'
+import type { UserInfo } from '@common/models/user'
 import { isUpcoming } from '@common/utils/date'
 import accumulateSignups from '@common/utils/signupAccumulator'
 import {
@@ -47,7 +51,7 @@ import {
   Trash2,
   type LucideIcon,
 } from 'lucide-react'
-import { useMemo, useState, type ComponentProps } from 'react'
+import { useEffect, useMemo, useState, type ComponentProps } from 'react'
 import { useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { twMerge } from 'tailwind-merge'
@@ -70,7 +74,17 @@ function Signup({
     session.signups.find(s => s.user.id === loggedInUser?.id)?.response
   )
 
+  const [userToAdd, setUserToAdd] = useState<UserInfo | null>(null)
+  const [addResponse, setAddResponse] = useState<SessionResponse>('yes')
+
+  useEffect(() => {
+    setMyResponse(
+      session.signups.find(s => s.user.id === loggedInUser?.id)?.response
+    )
+  }, [session.signups, loggedInUser?.id])
+
   const isAdmin = isLoggedIn && loggedInUser.role !== 'user'
+  const canManageParticipants = isAdmin
   const responses: { response: SessionResponse; Icon: LucideIcon }[] = [
     { response: 'yes', Icon: CircleCheck },
     { response: 'maybe', Icon: CircleQuestionMark },
@@ -99,6 +113,17 @@ function Signup({
           return rankA - rankB
         }),
     [session, timeEntries, matches, users, rankings]
+  )
+
+  const addableUsers = useMemo(() => {
+    if (!users) return []
+    const signedUpIds = new Set(session.signups.map(s => s.user.id))
+    return users.filter(u => !signedUpIds.has(u.id))
+  }, [users, session.signups])
+
+  const addableItems = useMemo(
+    () => addableUsers.map(userToLookupItem),
+    [addableUsers]
   )
 
   if (isLoadingData)
@@ -130,6 +155,79 @@ function Signup({
     )
   }
 
+  function handleModSetResponse(userId: string, response: SessionResponse) {
+    toast.promise(
+      socket
+        .emitWithAck('rsvp_session', {
+          type: 'RsvpSessionRequest',
+          session: session.id,
+          user: userId,
+          response,
+        })
+        .then(res => {
+          if (!res.success) throw new Error(res.message)
+          if (userId === loggedInUser?.id) setMyResponse(response)
+        }),
+      {
+        loading: loc.no.session.participants.modRsvpToast.loading,
+        success: loc.no.session.participants.modRsvpToast.success,
+        error: loc.no.session.participants.modRsvpToast.error,
+      }
+    )
+  }
+
+  function handleRemoveSignup(userId: string) {
+    toast.promise(
+      socket
+        .emitWithAck('remove_session_signup', {
+          type: 'RemoveSessionSignupRequest',
+          session: session.id,
+          user: userId,
+        })
+        .then(res => {
+          if (!res.success) throw new Error(res.message)
+          if (userId === loggedInUser?.id) setMyResponse(undefined)
+        }),
+      {
+        loading: loc.no.session.participants.removeToast.loading,
+        success: loc.no.session.participants.removeToast.success,
+        error: loc.no.session.participants.removeToast.error,
+      }
+    )
+  }
+
+  function handleAddParticipant() {
+    if (!userToAdd) return
+    toast.promise(
+      socket
+        .emitWithAck('rsvp_session', {
+          type: 'RsvpSessionRequest',
+          session: session.id,
+          user: userToAdd.id,
+          response: addResponse,
+        })
+        .then(res => {
+          if (!res.success) throw new Error(res.message)
+          setUserToAdd(null)
+          if (userToAdd.id === loggedInUser?.id) setMyResponse(addResponse)
+        }),
+      {
+        loading: loc.no.session.participants.addToast.loading,
+        success: loc.no.session.participants.addToast.success,
+        error: loc.no.session.participants.addToast.error,
+      }
+    )
+  }
+
+  const showSelfQuickRsvpHeader =
+    (isUpcoming(session) || isAdmin) &&
+    isLoggedIn &&
+    myResponse &&
+    !(canManageParticipants && myResponse)
+
+  const hideSelfRsvpButtons =
+    !isUpcoming(session) || !isLoggedIn || !!myResponse
+
   return (
     <div className={twMerge('flex flex-col gap-4', className)} {...rest}>
       <div className='flex justify-between'>
@@ -140,7 +238,7 @@ function Signup({
         </h3>
 
         <div>
-          {(isUpcoming(session) || isAdmin) && isLoggedIn && myResponse && (
+          {showSelfQuickRsvpHeader && (
             <Select
               disabled={disabled}
               value={myResponse}
@@ -163,7 +261,7 @@ function Signup({
 
       <div
         className='flex items-center justify-center gap-2'
-        hidden={!isUpcoming(session) || !isLoggedIn || !!myResponse}>
+        hidden={hideSelfRsvpButtons}>
         {responses.map(({ response, Icon }) => (
           <Button
             key={response}
@@ -175,6 +273,56 @@ function Signup({
           </Button>
         ))}
       </div>
+
+      {canManageParticipants && addableUsers.length > 0 && (
+        <div className='border-border bg-background-secondary/80 flex flex-col gap-3 rounded-sm border p-3'>
+          <h4 className='text-sm font-medium'>
+            {loc.no.session.participants.addTitle}
+          </h4>
+          <div className='flex flex-col gap-3 md:flex-row md:items-end'>
+            <div className='min-w-0 flex-1'>
+              <Combobox
+                disabled={disabled}
+                selected={
+                  userToAdd
+                    ? (addableItems.find(i => i.id === userToAdd.id) ?? null)
+                    : null
+                }
+                setSelected={v => setUserToAdd(v ?? null)}
+                items={addableItems}
+                CustomRow={UserRow}
+                placeholder={loc.no.session.participants.addPlaceholder}
+              />
+            </div>
+            <div className='flex flex-col gap-1'>
+              <Label className='text-label-muted text-xs'>
+                {loc.no.session.participants.addResponse}
+              </Label>
+              <Select
+                disabled={disabled}
+                value={addResponse}
+                onValueChange={v => setAddResponse(v as SessionResponse)}>
+                <SelectTrigger className='w-full md:w-[160px]'>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {responses.map(({ response, Icon }) => (
+                    <SelectItem key={response} value={response}>
+                      <Icon className='size-4' />
+                      {loc.no.session.rsvp.responses[response]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              disabled={disabled || !userToAdd}
+              onClick={handleAddParticipant}>
+              {loc.no.session.participants.addSubmit}
+            </Button>
+          </div>
+        </div>
+      )}
 
       {accumulatedSignups.length === 0 && (
         <Empty className='border-input text-muted-foreground border text-sm'>
@@ -196,13 +344,57 @@ function Signup({
             <div className='bg-background-secondary rounded-sm'>
               {accumulatedSignups
                 .filter(s => s.response === response)
-                .map(({ user }) => (
-                  <UserRow
-                    key={user.id}
-                    item={user}
-                    className='py-3 first:pt-4 last:pb-4'
-                  />
-                ))}
+                .map(({ user }) => {
+                  const hasSignupRow = session.signups.some(
+                    su => su.user.id === user.id
+                  )
+                  return (
+                    <div
+                      key={user.id}
+                      className='border-border flex flex-col gap-2 border-b px-2 py-3 last:border-b-0 sm:flex-row sm:items-center sm:gap-3'>
+                      <UserRow
+                        item={user}
+                        className='min-w-0 flex-1 py-0 first:pt-0 last:pb-0'
+                      />
+                      {canManageParticipants && (
+                        <div className='flex shrink-0 flex-wrap items-center gap-2 sm:justify-end'>
+                          <Select
+                            disabled={disabled}
+                            value={response}
+                            onValueChange={v =>
+                              handleModSetResponse(
+                                user.id,
+                                v as SessionResponse
+                              )
+                            }>
+                            <SelectTrigger className='w-[160px]'>
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {responses.map(({ response: r, Icon }) => (
+                                <SelectItem key={r} value={r}>
+                                  <Icon className='size-4' />
+                                  {loc.no.session.rsvp.responses[r]}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          {hasSignupRow && (
+                            <ConfirmationButton
+                              size='sm'
+                              variant='outline'
+                              disabled={disabled}
+                              confirmText={loc.no.common.continue}
+                              onClick={() => handleRemoveSignup(user.id)}>
+                              <Trash2 className='size-4' />
+                              {loc.no.session.participants.remove}
+                            </ConfirmationButton>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
             </div>
           </div>
         )

--- a/frontend/lib/locales.ts
+++ b/frontend/lib/locales.ts
@@ -173,6 +173,30 @@ const no = {
     },
     errorMessages: {
       no_edit_historical: 'Du kan ikke endre svar på en session tilbake i tid.',
+      no_signup_to_remove:
+        'Fant ingen aktiv påmelding å fjerne for denne brukeren.',
+    },
+    participants: {
+      addTitle: 'Legg til deltaker',
+      addPlaceholder: 'Velg bruker',
+      addResponse: 'Svar',
+      addSubmit: 'Legg til',
+      addToast: {
+        loading: 'Legger til deltaker...',
+        success: 'Deltaker lagt til',
+        error: (err: Error) => `Kunne ikke legge til: ${err.message}`,
+      },
+      modRsvpToast: {
+        loading: 'Oppdaterer deltaker...',
+        success: 'Deltaker oppdatert',
+        error: (err: Error) => `Kunne ikke oppdatere: ${err.message}`,
+      },
+      remove: 'Fjern påmelding',
+      removeToast: {
+        loading: 'Fjerner deltaker...',
+        success: 'Deltaker fjernet fra påmelding',
+        error: (err: Error) => `Kunne ikke fjerne: ${err.message}`,
+      },
     },
   },
   match: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Admins and moderators can manage who is on a session’s attendance list: add users who have not RSVP’d (any response), change any participant’s yes/maybe/no, and remove users who have an explicit signup row (soft-delete).

## Backend

- New `remove_session_signup` Socket.IO event with `RemoveSessionSignupRequest`; validates role, session, and an active signup before setting `deletedAt`.
- Add/remove flows broadcast `all_sessions` and reschedule the session scheduler, consistent with existing RSVP behavior.
- `rsvp_session` already allowed moderators to set responses for other users; no change required there.

## Frontend

- On the session detail page, moderators see a combobox to add users (only those without a current signup), a response selector, and per-row controls to update status or remove the signup when one exists.
- When a moderator has already RSVP’d, the compact header RSVP control is hidden so they use the same per-row controls as everyone else (avoids duplicate UI).

## Verification

- `npm run check` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-724111a6-567b-468c-86ef-04baf7e7a4cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-724111a6-567b-468c-86ef-04baf7e7a4cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

