### PR TITLE
feat: automatic Trackmania 2020 result capture (Ubekrefta runder)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-PRIVATE_KEY="<secret>"
+SECRET="<jwt-signing-secret>"
+CAPTURE_TOKEN="<shared-secret-for-the-openplanet-plugin>"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See `docs/autocapture/capture-contract.md` for the full HTTP contract (payload s
 - `ORIGIN` (required in production): Allowed frontend origin for CORS.
 - `TOKEN_EXPIRY_H` (optional): Override default 1-hour auth token expiry.
 - `CAPTURE_TOKEN` (optional): Shared secret for the Trackmania auto-capture ingest endpoint. If unset, the endpoint is disabled.
-- `.env.example` also exposes `PRIVATE_KEY` for local defaults—never commit secrets.
+- `.env.example` also exposes `SECRET` for local defaults—never commit secrets.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,23 @@ Admins can visit `/admin` to upload and download CSV files for all database tabl
 
 The `/sessions` route shows upcoming and past events. Authorized users may create, edit, or delete sessions with optional locations and descriptions. Attendees can RSVP; ICS feeds are available via `/api/sessions/calendar.ics`, and individual invites can be downloaded per session. Session deletion is soft-delete (retained for audit), cascading to all signups, and only available to admin/moderator roles.
 
+## Auto-capture (Trackmania 2020)
+
+Chugmania can receive finish times directly from a Trackmania 2020 PC session. A separate Openplanet plugin (lives in its own repository) POSTs heat results to `POST /api/capture/heat` after each map visit. Received times appear as faded "Ubekrefta runder" rows at the top of the active session page, where an admin or moderator can click a row, assign player(s) from a dropdown, and confirm — writing the entries (and a completed match for 1v1) through the normal reactive Socket.IO path. Manual entry continues to work in parallel.
+
+**Enabling capture:**
+
+- Set `CAPTURE_TOKEN` in `.env` to a shared secret; the plugin sends it as `Authorization: Bearer <token>`. If the variable is unset the endpoint returns `503` and capture is disabled.
+- On the session page, an admin clicks **Aktiver registrering** to mark that session as "live for capture". Heats received while no session is active are silently ignored (the plugin receives `{ stored: false }` and should not retry).
+
+See `docs/autocapture/capture-contract.md` for the full HTTP contract (payload shape, versioning, idempotency).
+
 ## Configuration
 
 - `SECRET` (required): JWT signing key; use a strong random value.
 - `ORIGIN` (required in production): Allowed frontend origin for CORS.
 - `TOKEN_EXPIRY_H` (optional): Override default 1-hour auth token expiry.
+- `CAPTURE_TOKEN` (optional): Shared secret for the Trackmania auto-capture ingest endpoint. If unset, the endpoint is disabled.
 - `.env.example` also exposes `PRIVATE_KEY` for local defaults—never commit secrets.
 
 ## Docker

--- a/backend/database/schema.ts
+++ b/backend/database/schema.ts
@@ -97,7 +97,7 @@ export const timeEntries = sqliteTable('time_entries', {
   source: text()
     .$type<'manual' | 'auto'>()
     .notNull()
-    .$default(() => 'manual'),
+    .default('manual'),
 })
 
 export const matches = sqliteTable('matches', {

--- a/backend/database/schema.ts
+++ b/backend/database/schema.ts
@@ -51,9 +51,12 @@ export type TrackType = 'drift' | 'valley' | 'lagoon' | 'stadium'
 
 export const tracks = sqliteTable('tracks', {
   ...metadata,
-  number: integer().notNull(),
-  level: text().$type<TrackLevel>().notNull(),
-  type: text().$type<TrackType>().notNull(),
+  number: integer(),
+  level: text().$type<TrackLevel>(),
+  type: text().$type<TrackType>(),
+  mapUid: text('map_uid').unique(),
+  name: text(),
+  author: text(),
 })
 
 export const sessions = sqliteTable('sessions', {
@@ -91,6 +94,10 @@ export const timeEntries = sqliteTable('time_entries', {
   duration: integer('duration_ms'),
   amount: integer('amount_l').notNull().default(0.5),
   comment: text(),
+  source: text()
+    .$type<'manual' | 'auto'>()
+    .notNull()
+    .$default(() => 'manual'),
 })
 
 export const matches = sqliteTable('matches', {
@@ -166,4 +173,18 @@ export const tournamentMatches = sqliteTable('tournament_matches', {
   sourceMatchBProgression: text(
     'source_match_b_progression'
   ).$type<MatchProgression>(),
+})
+
+export const unconfirmedLaps = sqliteTable('unconfirmed_laps', {
+  ...metadata,
+  session: text()
+    .notNull()
+    .references(() => sessions.id, { onDelete: 'cascade' }),
+  track: text()
+    .notNull()
+    .references(() => tracks.id),
+  heatId: text('heat_id').notNull(),
+  slot: integer().notNull(),
+  duration: integer('duration_ms').notNull(),
+  playerCount: integer('player_count').notNull(),
 })

--- a/backend/src/managers/admin.manager.ts
+++ b/backend/src/managers/admin.manager.ts
@@ -19,6 +19,7 @@ import {
   tournamentMatches,
   tournaments,
   tracks,
+  unconfirmedLaps,
   users,
 } from '../../database/schema'
 import { broadcast } from '../server'
@@ -43,6 +44,7 @@ export default class AdminManager {
     groups: new Set(),
     groupPlayers: new Set(),
     tournamentMatches: new Set(),
+    unconfirmedLaps: new Set(),
   } satisfies Record<ExportCsvRequest['table'], Set<string>>
 
   private static readonly TABLE_MAP = {
@@ -56,6 +58,7 @@ export default class AdminManager {
     groups: groups,
     groupPlayers: groupPlayers,
     tournamentMatches: tournamentMatches,
+    unconfirmedLaps: unconfirmedLaps,
   } satisfies Record<ExportCsvRequest['table'], SQLiteTable>
 
   private static async importRows<T extends Record<string, any>>(

--- a/backend/src/managers/capture.logic.spec.ts
+++ b/backend/src/managers/capture.logic.spec.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  isHeatPayload,
+  templateFor,
+  winningSlot,
+  validateAssignments,
+} from './capture.logic'
+
+const validPayload = {
+  contractVersion: 1,
+  heatId: 'h1',
+  mapUid: 'map-uid',
+  mapName: 'My Map',
+  playerCount: 2,
+  results: [
+    { slot: 1, bestTimeMs: 42300 },
+    { slot: 2, bestTimeMs: 45100 },
+  ],
+}
+
+test('isHeatPayload accepts a valid payload', () => {
+  assert.equal(isHeatPayload(validPayload), true)
+})
+
+test('isHeatPayload rejects missing results', () => {
+  assert.equal(isHeatPayload({ ...validPayload, results: undefined }), false)
+})
+
+test('isHeatPayload rejects a non-numeric time', () => {
+  assert.equal(
+    isHeatPayload({ ...validPayload, results: [{ slot: 1, bestTimeMs: 'x' }] }),
+    false
+  )
+})
+
+test('templateFor maps player counts', () => {
+  assert.equal(templateFor(1), 'solo')
+  assert.equal(templateFor(2), 'duel')
+  assert.equal(templateFor(3), null)
+})
+
+test('winningSlot returns the faster slot', () => {
+  assert.equal(winningSlot([
+    { slot: 1, duration: 45100 },
+    { slot: 2, duration: 42300 },
+  ]), 2)
+})
+
+test('winningSlot returns null on a tie', () => {
+  assert.equal(winningSlot([
+    { slot: 1, duration: 42300 },
+    { slot: 2, duration: 42300 },
+  ]), null)
+})
+
+test('validateAssignments requires one per slot and distinct users for duels', () => {
+  const slots = [1, 2]
+  assert.equal(
+    validateAssignments(slots, [
+      { slot: 1, user: 'a' },
+      { slot: 2, user: 'b' },
+    ]),
+    null
+  )
+  assert.equal(
+    typeof validateAssignments(slots, [{ slot: 1, user: 'a' }]),
+    'string'
+  )
+  assert.equal(
+    typeof validateAssignments(slots, [
+      { slot: 1, user: 'a' },
+      { slot: 2, user: 'a' },
+    ]),
+    'string'
+  )
+})

--- a/backend/src/managers/capture.logic.spec.ts
+++ b/backend/src/managers/capture.logic.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import {
   isHeatPayload,
+  isSupportedHeat,
   templateFor,
   winningSlot,
   validateAssignments,
@@ -52,6 +53,22 @@ test('winningSlot returns null on a tie', () => {
     { slot: 1, duration: 42300 },
     { slot: 2, duration: 42300 },
   ]), null)
+})
+
+test('isSupportedHeat returns true for playerCount 1 with contractVersion 1', () => {
+  assert.equal(isSupportedHeat({ ...validPayload, playerCount: 1, results: [{ slot: 1, bestTimeMs: 42300 }] }), true)
+})
+
+test('isSupportedHeat returns true for playerCount 2 with contractVersion 1', () => {
+  assert.equal(isSupportedHeat({ ...validPayload, playerCount: 2 }), true)
+})
+
+test('isSupportedHeat returns false for playerCount 3', () => {
+  assert.equal(isSupportedHeat({ ...validPayload, playerCount: 3 }), false)
+})
+
+test('isSupportedHeat returns false when contractVersion is not 1', () => {
+  assert.equal(isSupportedHeat({ ...validPayload, contractVersion: 2 }), false)
 })
 
 test('validateAssignments requires one per slot and distinct users for duels', () => {

--- a/backend/src/managers/capture.logic.ts
+++ b/backend/src/managers/capture.logic.ts
@@ -1,6 +1,7 @@
-import type {
-  CaptureAssignment,
-  CaptureHeatPayload,
+import {
+  CAPTURE_CONTRACT_VERSION,
+  type CaptureAssignment,
+  type CaptureHeatPayload,
 } from '@common/models/capture'
 
 export function isHeatPayload(data: any): data is CaptureHeatPayload {
@@ -17,6 +18,13 @@ export function isHeatPayload(data: any): data is CaptureHeatPayload {
       typeof r.slot === 'number' &&
       typeof r.bestTimeMs === 'number' &&
       r.bestTimeMs > 0
+  )
+}
+
+export function isSupportedHeat(payload: CaptureHeatPayload): boolean {
+  return (
+    payload.contractVersion === CAPTURE_CONTRACT_VERSION &&
+    templateFor(payload.playerCount) !== null
   )
 }
 

--- a/backend/src/managers/capture.logic.ts
+++ b/backend/src/managers/capture.logic.ts
@@ -1,0 +1,53 @@
+import type {
+  CaptureAssignment,
+  CaptureHeatPayload,
+} from '@common/models/capture'
+
+export function isHeatPayload(data: any): data is CaptureHeatPayload {
+  if (typeof data !== 'object' || data === null) return false
+  if (typeof data.heatId !== 'string' || data.heatId.length === 0) return false
+  if (typeof data.mapUid !== 'string' || data.mapUid.length === 0) return false
+  if (typeof data.mapName !== 'string') return false
+  if (typeof data.playerCount !== 'number') return false
+  if (!Array.isArray(data.results) || data.results.length === 0) return false
+  return data.results.every(
+    (r: any) =>
+      typeof r === 'object' &&
+      r !== null &&
+      typeof r.slot === 'number' &&
+      typeof r.bestTimeMs === 'number' &&
+      r.bestTimeMs > 0
+  )
+}
+
+export function templateFor(playerCount: number): 'solo' | 'duel' | null {
+  if (playerCount === 1) return 'solo'
+  if (playerCount === 2) return 'duel'
+  return null
+}
+
+export function winningSlot(
+  laps: { slot: number; duration: number }[]
+): number | null {
+  if (laps.length < 2) return laps[0]?.slot ?? null
+  const sorted = [...laps].sort((a, b) => a.duration - b.duration)
+  if (sorted[0].duration === sorted[1].duration) return null
+  return sorted[0].slot
+}
+
+export function validateAssignments(
+  slots: number[],
+  assignments: CaptureAssignment[]
+): string | null {
+  for (const slot of slots) {
+    const found = assignments.find(a => a.slot === slot)
+    if (!found || typeof found.user !== 'string' || found.user.length === 0) {
+      return `Mangler spiller for plass ${slot}`
+    }
+  }
+  const users = assignments.map(a => a.user)
+  if (new Set(users).size !== users.length) {
+    return 'Samme spiller kan ikke stå på begge plassene'
+  }
+  return null
+}

--- a/backend/src/managers/capture.manager.ts
+++ b/backend/src/managers/capture.manager.ts
@@ -10,7 +10,7 @@ import loc from '../../../frontend/lib/locales'
 import db from '../../database/database'
 import { broadcast, type TypedSocket } from '../server'
 import AuthManager from './auth.manager'
-import { isHeatPayload } from './capture.logic'
+import { isHeatPayload, isSupportedHeat } from './capture.logic'
 import {
   confirmCapture,
   discardCapture,
@@ -34,6 +34,10 @@ export default class CaptureManager {
   static async ingestHeat(body: unknown): Promise<boolean> {
     if (!isHeatPayload(body)) {
       throw new Error(loc.no.error.messages.invalid_request('CaptureHeatPayload'))
+    }
+    if (!isSupportedHeat(body)) {
+      console.debug(new Date().toISOString(), 'Capture ignored — unsupported heat', body.heatId, body.playerCount, body.contractVersion)
+      return false
     }
     if (!CaptureManager.activeSessionId) {
       console.debug(

--- a/backend/src/managers/capture.manager.ts
+++ b/backend/src/managers/capture.manager.ts
@@ -1,0 +1,110 @@
+import {
+  isConfirmCaptureRequest,
+  isDiscardCaptureRequest,
+  isSetActiveSessionRequest,
+  type CaptureState,
+  type UnconfirmedRound,
+} from '@common/models/capture'
+import type { EventReq, EventRes } from '@common/models/socket.io'
+import loc from '../../../frontend/lib/locales'
+import db from '../../database/database'
+import { broadcast, type TypedSocket } from '../server'
+import AuthManager from './auth.manager'
+import { isHeatPayload } from './capture.logic'
+import {
+  confirmCapture,
+  discardCapture,
+  getUnconfirmedRounds,
+  ingestHeat,
+} from './capture.store'
+import RatingManager from './rating.manager'
+
+export default class CaptureManager {
+  private static activeSessionId: string | null = null
+
+  static getCaptureState(): CaptureState {
+    return { activeSessionId: CaptureManager.activeSessionId }
+  }
+
+  static async getUnconfirmedRounds(): Promise<UnconfirmedRound[]> {
+    return getUnconfirmedRounds(db)
+  }
+
+  // Called by the HTTP route. Returns true if the heat was stored, false if ignored.
+  static async ingestHeat(body: unknown): Promise<boolean> {
+    if (!isHeatPayload(body)) {
+      throw new Error(loc.no.error.messages.invalid_request('CaptureHeatPayload'))
+    }
+    if (!CaptureManager.activeSessionId) {
+      console.debug(
+        new Date().toISOString(),
+        'Capture ignored — no active session',
+        body.heatId
+      )
+      return false
+    }
+    await ingestHeat(db, body, CaptureManager.activeSessionId)
+    broadcast('all_unconfirmed_rounds', await getUnconfirmedRounds(db))
+    return true
+  }
+
+  static async onSetActiveSession(
+    socket: TypedSocket,
+    request: EventReq<'set_active_session'>
+  ): Promise<EventRes<'set_active_session'>> {
+    if (!isSetActiveSessionRequest(request)) {
+      throw new Error(
+        loc.no.error.messages.invalid_request('SetActiveSessionRequest')
+      )
+    }
+    await AuthManager.checkAuth(socket, ['admin', 'moderator'])
+    CaptureManager.activeSessionId = request.sessionId
+    broadcast('capture_state', CaptureManager.getCaptureState())
+    return { success: true }
+  }
+
+  static async onConfirmCapture(
+    socket: TypedSocket,
+    request: EventReq<'confirm_capture'>
+  ): Promise<EventRes<'confirm_capture'>> {
+    if (!isConfirmCaptureRequest(request)) {
+      throw new Error(
+        loc.no.error.messages.invalid_request('ConfirmCaptureRequest')
+      )
+    }
+    await AuthManager.checkAuth(socket, ['admin', 'moderator'])
+    await confirmCapture(db, request.heatId, request.assignments)
+
+    await RatingManager.recalculate()
+    broadcast('all_unconfirmed_rounds', await getUnconfirmedRounds(db))
+    broadcast('all_time_entries', await TimeEntryFeed())
+    broadcast('all_matches', await MatchFeed())
+    broadcast('all_rankings', await RatingManager.onGetRatings())
+    return { success: true }
+  }
+
+  static async onDiscardCapture(
+    socket: TypedSocket,
+    request: EventReq<'discard_capture'>
+  ): Promise<EventRes<'discard_capture'>> {
+    if (!isDiscardCaptureRequest(request)) {
+      throw new Error(
+        loc.no.error.messages.invalid_request('DiscardCaptureRequest')
+      )
+    }
+    await AuthManager.checkAuth(socket, ['admin', 'moderator'])
+    await discardCapture(db, request.heatId)
+    broadcast('all_unconfirmed_rounds', await getUnconfirmedRounds(db))
+    return { success: true }
+  }
+}
+
+async function TimeEntryFeed() {
+  const { default: TimeEntryManager } = await import('./timeEntry.manager')
+  return TimeEntryManager.getAllTimeEntries()
+}
+
+async function MatchFeed() {
+  const { default: MatchManager } = await import('./match.manager')
+  return MatchManager.getAllMatches()
+}

--- a/backend/src/managers/capture.store.spec.ts
+++ b/backend/src/managers/capture.store.spec.ts
@@ -1,0 +1,63 @@
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import * as schema from '../../database/schema'
+import { sessions } from '../../database/schema'
+import { getUnconfirmedRounds, ingestHeat } from './capture.store'
+
+type Db = ReturnType<typeof drizzle<typeof schema>>
+
+let db: Db
+let sessionId: string
+
+beforeEach(async () => {
+  const sqlite = new Database(':memory:')
+  db = drizzle(sqlite, { schema })
+  migrate(db, { migrationsFolder: 'drizzle' })
+  const [s] = await db
+    .insert(sessions)
+    .values({ name: 'Test', date: new Date() })
+    .returning()
+  sessionId = s.id
+})
+
+const payload = {
+  contractVersion: 1,
+  heatId: 'heat-1',
+  mapUid: 'uid-1',
+  mapName: 'Map One',
+  playerCount: 2,
+  results: [
+    { slot: 1, bestTimeMs: 42300 },
+    { slot: 2, bestTimeMs: 45100 },
+  ],
+}
+
+test('ingestHeat creates a track and two laps, grouped into one round', async () => {
+  await ingestHeat(db, payload, sessionId)
+  const rounds = await getUnconfirmedRounds(db)
+  assert.equal(rounds.length, 1)
+  assert.equal(rounds[0].heatId, 'heat-1')
+  assert.equal(rounds[0].playerCount, 2)
+  assert.equal(rounds[0].laps.length, 2)
+  const tracks = await db.select().from(schema.tracks)
+  assert.equal(tracks.length, 1)
+  assert.equal(tracks[0].mapUid, 'uid-1')
+})
+
+test('ingestHeat reuses an existing track for the same mapUid', async () => {
+  await ingestHeat(db, payload, sessionId)
+  await ingestHeat(db, { ...payload, heatId: 'heat-2' }, sessionId)
+  const tracks = await db.select().from(schema.tracks)
+  assert.equal(tracks.length, 1)
+})
+
+test('ingestHeat is idempotent on a duplicate heatId', async () => {
+  await ingestHeat(db, payload, sessionId)
+  await ingestHeat(db, payload, sessionId)
+  const rounds = await getUnconfirmedRounds(db)
+  assert.equal(rounds.length, 1)
+  assert.equal(rounds[0].laps.length, 2)
+})

--- a/backend/src/managers/capture.store.spec.ts
+++ b/backend/src/managers/capture.store.spec.ts
@@ -4,8 +4,8 @@ import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
 import assert from 'node:assert/strict'
 import { beforeEach, test } from 'node:test'
 import * as schema from '../../database/schema'
-import { sessions } from '../../database/schema'
-import { getUnconfirmedRounds, ingestHeat } from './capture.store'
+import { matches, sessions, timeEntries, users } from '../../database/schema'
+import { confirmCapture, discardCapture, getUnconfirmedRounds, ingestHeat } from './capture.store'
 
 type Db = ReturnType<typeof drizzle<typeof schema>>
 
@@ -60,4 +60,63 @@ test('ingestHeat is idempotent on a duplicate heatId', async () => {
   const rounds = await getUnconfirmedRounds(db)
   assert.equal(rounds.length, 1)
   assert.equal(rounds[0].laps.length, 2)
+})
+
+async function makeUser(db: Db, name: string): Promise<string> {
+  const [u] = await db
+    .insert(users)
+    .values({
+      email: `${name}@x.no`,
+      firstName: name,
+      passwordHash: Buffer.from('x'),
+    })
+    .returning()
+  return u.id
+}
+
+test('confirmCapture writes two auto time entries + a completed match, deletes laps', async () => {
+  await ingestHeat(db, payload, sessionId)
+  const a = await makeUser(db, 'alice')
+  const b = await makeUser(db, 'bob')
+
+  await confirmCapture(db, 'heat-1', [
+    { slot: 1, user: a },
+    { slot: 2, user: b },
+  ])
+
+  const entries = await db.select().from(timeEntries)
+  assert.equal(entries.length, 2)
+  assert.equal(entries.every(e => e.source === 'auto'), true)
+  assert.equal(entries.every(e => e.session === sessionId), true)
+
+  const [match] = await db.select().from(matches)
+  assert.equal(match.status, 'completed')
+  assert.equal(match.winner, a) // slot 1 was faster (42300 < 45100)
+
+  const rounds = await getUnconfirmedRounds(db)
+  assert.equal(rounds.length, 0)
+})
+
+test('confirmCapture for a solo round writes one entry and no match', async () => {
+  await ingestHeat(
+    db,
+    {
+      ...payload,
+      heatId: 'solo-1',
+      playerCount: 1,
+      results: [{ slot: 1, bestTimeMs: 40000 }],
+    },
+    sessionId
+  )
+  const a = await makeUser(db, 'solo')
+  await confirmCapture(db, 'solo-1', [{ slot: 1, user: a }])
+  assert.equal((await db.select().from(timeEntries)).length, 1)
+  assert.equal((await db.select().from(matches)).length, 0)
+})
+
+test('discardCapture removes laps without writing entries', async () => {
+  await ingestHeat(db, payload, sessionId)
+  await discardCapture(db, 'heat-1')
+  assert.equal((await getUnconfirmedRounds(db)).length, 0)
+  assert.equal((await db.select().from(timeEntries)).length, 0)
 })

--- a/backend/src/managers/capture.store.ts
+++ b/backend/src/managers/capture.store.ts
@@ -1,0 +1,95 @@
+import type {
+  CaptureHeatPayload,
+  UnconfirmedRound,
+} from '@common/models/capture'
+import { and, eq, isNull } from 'drizzle-orm'
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
+import * as schema from '../../database/schema'
+import { tracks, unconfirmedLaps } from '../../database/schema'
+
+type Db = BetterSQLite3Database<typeof schema>
+
+async function resolveTrackId(
+  db: Db,
+  payload: CaptureHeatPayload
+): Promise<string> {
+  const existing = await db.query.tracks.findFirst({
+    where: eq(tracks.mapUid, payload.mapUid),
+  })
+  if (existing) return existing.id
+  const [created] = await db
+    .insert(tracks)
+    .values({
+      mapUid: payload.mapUid,
+      name: payload.mapName,
+      author: payload.mapAuthor ?? null,
+    })
+    .returning()
+  return created.id
+}
+
+export async function ingestHeat(
+  db: Db,
+  payload: CaptureHeatPayload,
+  sessionId: string
+): Promise<void> {
+  const already = await db.query.unconfirmedLaps.findFirst({
+    where: eq(unconfirmedLaps.heatId, payload.heatId),
+  })
+  if (already) return
+
+  const trackId = await resolveTrackId(db, payload)
+
+  await db.insert(unconfirmedLaps).values(
+    payload.results.map(r => ({
+      session: sessionId,
+      track: trackId,
+      heatId: payload.heatId,
+      slot: r.slot,
+      duration: r.bestTimeMs,
+      playerCount: payload.playerCount,
+    }))
+  )
+}
+
+export async function getUnconfirmedRounds(
+  db: Db
+): Promise<UnconfirmedRound[]> {
+  const rows = await db
+    .select()
+    .from(unconfirmedLaps)
+    .where(isNull(unconfirmedLaps.deletedAt))
+
+  const byHeat = new Map<string, UnconfirmedRound>()
+  for (const row of rows) {
+    let round = byHeat.get(row.heatId)
+    if (!round) {
+      round = {
+        heatId: row.heatId,
+        session: row.session,
+        track: row.track,
+        playerCount: row.playerCount,
+        createdAt: row.createdAt,
+        laps: [],
+      }
+      byHeat.set(row.heatId, round)
+    }
+    round.laps.push({ slot: row.slot, duration: row.duration })
+  }
+  return [...byHeat.values()].sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+  )
+}
+
+export async function lapsForHeat(db: Db, heatId: string) {
+  return db
+    .select()
+    .from(unconfirmedLaps)
+    .where(
+      and(eq(unconfirmedLaps.heatId, heatId), isNull(unconfirmedLaps.deletedAt))
+    )
+}
+
+export async function deleteHeat(db: Db, heatId: string): Promise<void> {
+  await db.delete(unconfirmedLaps).where(eq(unconfirmedLaps.heatId, heatId))
+}

--- a/backend/src/managers/capture.store.ts
+++ b/backend/src/managers/capture.store.ts
@@ -1,11 +1,13 @@
 import type {
+  CaptureAssignment as Assignment,
   CaptureHeatPayload,
   UnconfirmedRound,
 } from '@common/models/capture'
 import { and, eq, isNull } from 'drizzle-orm'
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
 import * as schema from '../../database/schema'
-import { tracks, unconfirmedLaps } from '../../database/schema'
+import { matches, timeEntries, tracks, unconfirmedLaps } from '../../database/schema'
+import { validateAssignments, winningSlot } from './capture.logic'
 
 type Db = BetterSQLite3Database<typeof schema>
 
@@ -92,4 +94,54 @@ export async function lapsForHeat(db: Db, heatId: string) {
 
 export async function deleteHeat(db: Db, heatId: string): Promise<void> {
   await db.delete(unconfirmedLaps).where(eq(unconfirmedLaps.heatId, heatId))
+}
+
+export async function confirmCapture(
+  db: Db,
+  heatId: string,
+  assignments: Assignment[]
+): Promise<void> {
+  const laps = await lapsForHeat(db, heatId)
+  if (laps.length === 0) throw new Error('Fant ingen ubekrefta runde')
+
+  const slots = laps.map(l => l.slot)
+  const problem = validateAssignments(slots, assignments)
+  if (problem) throw new Error(problem)
+
+  const sessionId = laps[0].session
+  const trackId = laps[0].track
+
+  const entryValues = laps.map(lap => {
+    const assignment = assignments.find(a => a.slot === lap.slot)!
+    return {
+      user: assignment.user,
+      track: trackId,
+      session: sessionId,
+      duration: lap.duration,
+      source: 'auto' as const,
+    }
+  })
+  await db.insert(timeEntries).values(entryValues)
+
+  if (laps.length === 2) {
+    const winSlot = winningSlot(
+      laps.map(l => ({ slot: l.slot, duration: l.duration }))
+    )
+    const userForSlot = (slot: number) =>
+      assignments.find(a => a.slot === slot)!.user
+    await db.insert(matches).values({
+      user1: userForSlot(laps[0].slot),
+      user2: userForSlot(laps[1].slot),
+      track: trackId,
+      session: sessionId,
+      winner: winSlot === null ? null : userForSlot(winSlot),
+      status: 'completed',
+    })
+  }
+
+  await deleteHeat(db, heatId)
+}
+
+export async function discardCapture(db: Db, heatId: string): Promise<void> {
+  await deleteHeat(db, heatId)
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -13,6 +13,7 @@ import ViteExpress from 'vite-express'
 import AdminManager from './managers/admin.manager'
 import ApiManager from './managers/api.manager'
 import AuthManager from './managers/auth.manager'
+import CaptureManager from './managers/capture.manager'
 import MatchManager from './managers/match.manager'
 import RatingManager from './managers/rating.manager'
 import SessionManager from './managers/session.manager'
@@ -24,6 +25,7 @@ import UserManager from './managers/user.manager'
 
 const PORT = process.env.PORT ? Number.parseInt(process.env.PORT) : 6996
 const ORIGIN = new URL(process.env.ORIGIN ?? `http://localhost:${PORT}`)
+const CAPTURE_TOKEN = process.env.CAPTURE_TOKEN
 
 const app = express()
 const server = ViteExpress.listen(app, PORT)
@@ -54,6 +56,24 @@ app.get('/api/sessions/calendar.ics', (req, res) =>
   ApiManager.onGetCalendar(ORIGIN, req, res)
 )
 
+app.post('/api/capture/heat', express.json(), async (req, res) => {
+  if (!CAPTURE_TOKEN) {
+    res.status(503).json({ success: false, message: 'Capture disabled' })
+    return
+  }
+  const auth = req.header('authorization')
+  if (auth !== `Bearer ${CAPTURE_TOKEN}`) {
+    res.status(401).json({ success: false, message: 'Unauthorized' })
+    return
+  }
+  try {
+    const stored = await CaptureManager.ingestHeat(req.body)
+    res.status(200).json({ success: true, stored })
+  } catch (e) {
+    res.status(400).json({ success: false, message: (e as Error).message })
+  }
+})
+
 io.on('connect', s => Connect(s))
 
 // Initialize session scheduler when server starts
@@ -73,6 +93,8 @@ async function Connect(s: TypedSocket) {
   s.emit('all_matches', await MatchManager.getAllMatches())
   s.emit('all_rankings', await RatingManager.onGetRatings())
   s.emit('all_tournaments', await TournamentManager.getAllTournaments())
+  s.emit('capture_state', CaptureManager.getCaptureState())
+  s.emit('all_unconfirmed_rounds', await CaptureManager.getUnconfirmedRounds())
 
   s.on('disconnect', () =>
     console.debug(new Date().toISOString(), s.id, 'Disconnected')
@@ -104,6 +126,10 @@ async function Connect(s: TypedSocket) {
   setup(s, 'edit_tournament', TournamentManager.onEditTournament)
   setup(s, 'delete_tournament', TournamentManager.onDeleteTournament)
   setup(s, 'get_tournament_preview', TournamentManager.onGetTournamentPreview)
+
+  setup(s, 'set_active_session', CaptureManager.onSetActiveSession)
+  setup(s, 'confirm_capture', CaptureManager.onConfirmCapture)
+  setup(s, 'discard_capture', CaptureManager.onDiscardCapture)
 }
 
 function setup<Ev extends keyof ClientToServerEvents>(

--- a/common/models/capture.ts
+++ b/common/models/capture.ts
@@ -1,0 +1,86 @@
+import type { unconfirmedLaps } from '../../backend/database/schema'
+import type { Session } from './session'
+import type { Track } from './track'
+import type { User } from './user'
+
+export const CAPTURE_CONTRACT_VERSION = 1
+
+export type CaptureSlotResult = {
+  slot: number
+  bestTimeMs: number
+}
+
+export type CaptureHeatPayload = {
+  contractVersion: number
+  heatId: string
+  mapUid: string
+  mapName: string
+  mapAuthor?: string
+  playerCount: number
+  results: CaptureSlotResult[]
+  serverTime?: number
+}
+
+export type UnconfirmedLap = typeof unconfirmedLaps.$inferSelect
+
+export type UnconfirmedRound = {
+  heatId: string
+  session: Session['id']
+  track: Track['id']
+  playerCount: number
+  createdAt: Date
+  laps: { slot: number; duration: number }[]
+}
+
+export type CaptureState = {
+  activeSessionId: Session['id'] | null
+}
+
+export type CaptureAssignment = {
+  slot: number
+  user: User['id']
+}
+
+export type ConfirmCaptureRequest = {
+  type: 'ConfirmCaptureRequest'
+  heatId: string
+  assignments: CaptureAssignment[]
+}
+
+export function isConfirmCaptureRequest(
+  data: any
+): data is ConfirmCaptureRequest {
+  if (typeof data !== 'object' || data === null) return false
+  return (
+    data.type === 'ConfirmCaptureRequest' &&
+    typeof data.heatId === 'string' &&
+    Array.isArray(data.assignments)
+  )
+}
+
+export type DiscardCaptureRequest = {
+  type: 'DiscardCaptureRequest'
+  heatId: string
+}
+
+export function isDiscardCaptureRequest(
+  data: any
+): data is DiscardCaptureRequest {
+  if (typeof data !== 'object' || data === null) return false
+  return data.type === 'DiscardCaptureRequest' && typeof data.heatId === 'string'
+}
+
+export type SetActiveSessionRequest = {
+  type: 'SetActiveSessionRequest'
+  sessionId: Session['id'] | null
+}
+
+export function isSetActiveSessionRequest(
+  data: any
+): data is SetActiveSessionRequest {
+  if (typeof data !== 'object' || data === null) return false
+  return (
+    data.type === 'SetActiveSessionRequest' &&
+    (typeof data.sessionId === 'string' || data.sessionId === null)
+  )
+}

--- a/common/models/importCsv.ts
+++ b/common/models/importCsv.ts
@@ -1,8 +1,7 @@
-import type * as schema from '../../backend/database/schema'
 import type { SuccessResponse } from './socket.io'
 
 export type ImportCsvRequest = {
-  table: keyof typeof schema
+  table: ExportCsvRequest['table']
   content: string
 }
 
@@ -12,7 +11,18 @@ export function isImportCsvRequest(data: any): data is ImportCsvRequest {
 }
 
 export type ExportCsvRequest = {
-  table: keyof typeof schema
+  table:
+    | 'users'
+    | 'tracks'
+    | 'sessions'
+    | 'timeEntries'
+    | 'sessionSignups'
+    | 'matches'
+    | 'tournaments'
+    | 'groups'
+    | 'groupPlayers'
+    | 'tournamentMatches'
+    | 'unconfirmedLaps'
 }
 
 export function isExportCsvRequest(data: any): data is ExportCsvRequest {

--- a/common/models/socket.io.ts
+++ b/common/models/socket.io.ts
@@ -6,6 +6,13 @@ import type {
 } from '@common/models/importCsv'
 import type { LoginRequest, RegisterRequest } from './auth'
 import type {
+  CaptureState,
+  ConfirmCaptureRequest,
+  DiscardCaptureRequest,
+  SetActiveSessionRequest,
+  UnconfirmedRound,
+} from './capture'
+import type {
   CreateMatchRequest,
   DeleteMatchRequest,
   EditMatchRequest,
@@ -61,6 +68,8 @@ export interface ServerToClientEvents {
   all_matches: (r: Match[]) => void
   all_rankings: (r: Ranking[]) => void
   all_tournaments: (r: TournamentWithDetails[]) => void
+  all_unconfirmed_rounds: (r: UnconfirmedRound[]) => void
+  capture_state: (r: CaptureState) => void
 }
 
 export interface ClientToServerEvents {
@@ -147,6 +156,18 @@ export interface ClientToServerEvents {
   get_tournament_preview: (
     r: TournamentPreviewRequest,
     callback: (r: TournamentPreviewResponse | ErrorResponse) => void
+  ) => void
+  set_active_session: (
+    r: SetActiveSessionRequest,
+    callback: (r: SuccessResponse | ErrorResponse) => void
+  ) => void
+  confirm_capture: (
+    r: ConfirmCaptureRequest,
+    callback: (r: SuccessResponse | ErrorResponse) => void
+  ) => void
+  discard_capture: (
+    r: DiscardCaptureRequest,
+    callback: (r: SuccessResponse | ErrorResponse) => void
   ) => void
 }
 

--- a/docs/autocapture/capture-contract.md
+++ b/docs/autocapture/capture-contract.md
@@ -1,0 +1,39 @@
+# Capture HTTP contract (v1)
+
+The Openplanet plugin (separate repo) POSTs finished-heat results to Chugmania.
+
+## Endpoint
+`POST /api/capture/heat`
+
+## Auth
+Header `Authorization: Bearer <CAPTURE_TOKEN>` — must equal the backend's `CAPTURE_TOKEN` env var.
+If the backend has no `CAPTURE_TOKEN` set, the endpoint returns `503` (feature disabled).
+
+## Body (application/json)
+```json
+{
+  "contractVersion": 1,
+  "heatId": "string — stable across retries; idempotency key",
+  "mapUid": "string — TM2020 MapUid",
+  "mapName": "string",
+  "mapAuthor": "string (optional)",
+  "playerCount": 1,
+  "results": [{ "slot": 1, "bestTimeMs": 42300 }],
+  "serverTime": 0
+}
+```
+
+- `playerCount` 1 → solo, 2 → 1v1. Other values are logged and discarded.
+- `results` carries one entry per slot with that slot's best finish time for the map visit.
+
+## Responses
+- `200 { success: true, stored: boolean }` — `stored:false` means there was no active session, so the heat was ignored (do NOT retry).
+- `401` — bad/missing token.
+- `400` — malformed payload.
+- `503` — capture disabled (no token configured).
+
+## Idempotency
+Re-POSTing the same `heatId` is a no-op. Retry freely on network failure.
+
+## Versioning
+Bump `contractVersion` on any breaking change; the backend logic for v1 lives in `backend/src/managers/capture.logic.ts`.

--- a/docs/superpowers/plans/2026-06-08-chugmania-autocapture-backend-and-ui.md
+++ b/docs/superpowers/plans/2026-06-08-chugmania-autocapture-backend-and-ui.md
@@ -1,0 +1,1661 @@
+# Chugmania Auto-Capture — Backend + UI Implementation Plan (PR side)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add server-side ingest + a "Ubekrefta runder" assignment UI to Chugmania so finish times POSTed by the Openplanet plugin become confirmed time entries (and 1v1 matches) on the active session, running in parallel with manual entry.
+
+**Architecture:** A new HTTP endpoint `POST /api/capture/heat` (token-auth) writes unconfirmed laps to a new `unconfirmed_laps` table while a session is marked "active for capture". The frontend renders those as faded, nameless rows at the top of the active session; an admin clicks one and assigns player(s) via dropdowns (solo = 1, 1v1 = 2 + swap), which writes `time_entries` (+ a completed `matches` row for 1v1) through the existing reactive Socket.IO path. Capture logic is split into server-free modules (`capture.logic.ts`, `capture.store.ts`) so it is unit-testable without booting the server.
+
+**Tech Stack:** TypeScript (strict), Express 5, Socket.IO, Drizzle ORM + better-sqlite3, React 19 + Vite, Tailwind, Radix dialog, `node:test` + `node:assert` run via `tsx`.
+
+**Companion plan:** the Openplanet plugin lives in its own repo — see `2026-06-08-trackmania-openplanet-capture-plugin.md`. The seam between them is the contract documented in Task 9.
+
+**Conventions (from AGENTS.md):** 2-space indent, single quotes, **no semicolons**, trailing commas, explicit types at boundaries, no `any`, `loc.no.*` for all user strings, every mutation `broadcast`s via its `getAll*` fetch helper. Run `npm run check` before every commit.
+
+---
+
+## File structure
+
+**Backend / common (create):**
+- `common/models/capture.ts` — heat payload + contract version, `UnconfirmedLap`/`UnconfirmedRound` DTOs, confirm/discard/active-session request types + guards, `CaptureState`.
+- `backend/src/managers/capture.logic.ts` — pure, server-free functions (payload guard, winner, template, assignment validation).
+- `backend/src/managers/capture.logic.spec.ts` — unit tests.
+- `backend/src/managers/capture.store.ts` — pure DB ops taking `db` as a param (ingest, fetch, confirm, discard).
+- `backend/src/managers/capture.store.spec.ts` — integration tests against an in-memory DB.
+- `backend/src/managers/capture.manager.ts` — HTTP/socket handlers + in-memory active-session state.
+- `docs/autocapture/capture-contract.md` — the cross-repo HTTP contract.
+- `scripts/mock-plugin.ts` — dev script that POSTs a fake heat for manual E2E.
+
+**Backend / common (modify):**
+- `backend/database/schema.ts` — TM2020 track columns + relax nullables, `time_entries.source`, `unconfirmed_laps` table.
+- `backend/src/server.ts` — `express.json` + the capture route, `CAPTURE_TOKEN`, socket wiring, connect-time emits.
+- `common/models/socket.io.ts` — new events.
+- `common/models/importCsv.ts` — add `'unconfirmedLaps'` to the table union.
+- `backend/src/managers/admin.manager.ts` — `TABLE_MAP` + `EXCLUDED_COL_EXPORT`.
+- `.env.example` — add `CAPTURE_TOKEN`, fix stale `PRIVATE_KEY`.
+- `package.json` — add `test` script.
+
+**Frontend (create):**
+- `frontend/components/capture/UnconfirmedRoundsTable.tsx`
+- `frontend/components/capture/ConfirmRoundDialog.tsx`
+- `frontend/components/capture/ActiveSessionControl.tsx`
+
+**Frontend (modify):**
+- `frontend/contexts/DataContext.tsx` — store `all_unconfirmed_rounds` + `capture_state`.
+- `frontend/app/pages/SessionPage.tsx` — render the control + faded table on the active session.
+- `frontend/lib/locales.ts` — capture strings + `admin.tables` entry.
+
+---
+
+## Task 0: Test tooling
+
+**Files:**
+- Modify: `package.json` (scripts)
+
+- [ ] **Step 1: Add a test script**
+
+In `package.json` `scripts`, add after `"check"`:
+
+```json
+"test": "tsx --test \"backend/**/*.spec.ts\"",
+```
+
+- [ ] **Step 2: Verify the runner works with a throwaway spec**
+
+Create `backend/src/managers/_smoke.spec.ts`:
+
+```ts
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+test('runner works', () => {
+  assert.equal(1 + 1, 2)
+})
+```
+
+Run: `npx tsx --test backend/src/managers/_smoke.spec.ts`
+Expected: `# pass 1`.
+
+- [ ] **Step 3: Delete the smoke spec and commit**
+
+```bash
+rm backend/src/managers/_smoke.spec.ts
+git add package.json
+git commit -m "chore: add tsx-based node:test script"
+```
+
+---
+
+## Task 1: Schema changes + migration
+
+**Files:**
+- Modify: `backend/database/schema.ts`
+
+- [ ] **Step 1: Relax Turbo track columns and add TM2020 map columns**
+
+In `backend/database/schema.ts`, replace the `tracks` table (lines 52-57) with:
+
+```ts
+export const tracks = sqliteTable('tracks', {
+  ...metadata,
+  number: integer(),
+  level: text().$type<TrackLevel>(),
+  type: text().$type<TrackType>(),
+  mapUid: text('map_uid').unique(),
+  name: text(),
+  author: text(),
+})
+```
+
+- [ ] **Step 2: Add `source` to time entries**
+
+In the `timeEntries` table, add after the `comment` column:
+
+```ts
+  source: text()
+    .$type<'manual' | 'auto'>()
+    .notNull()
+    .$default(() => 'manual'),
+```
+
+- [ ] **Step 3: Add the `unconfirmed_laps` table**
+
+Append at the end of `backend/database/schema.ts`:
+
+```ts
+export const unconfirmedLaps = sqliteTable('unconfirmed_laps', {
+  ...metadata,
+  session: text()
+    .notNull()
+    .references(() => sessions.id, { onDelete: 'cascade' }),
+  track: text()
+    .notNull()
+    .references(() => tracks.id),
+  heatId: text('heat_id').notNull(),
+  slot: integer().notNull(),
+  duration: integer('duration_ms').notNull(),
+  playerCount: integer('player_count').notNull(),
+})
+```
+
+- [ ] **Step 4: Generate the migration**
+
+Run: `npm run db:gen`
+Expected: a new file under `drizzle/` (e.g. `drizzle/0007_*.sql`) creating `unconfirmed_laps`, altering `tracks`, and adding `time_entries.source`.
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `npm run check`
+Expected: passes (existing `Track`/`TimeEntry` models pick up the new columns via `$inferSelect`).
+
+```bash
+git add backend/database/schema.ts drizzle/
+git commit -m "feat(db): add TM2020 map fields, time_entries.source, unconfirmed_laps"
+```
+
+---
+
+## Task 2: Capture common models
+
+**Files:**
+- Create: `common/models/capture.ts`
+
+- [ ] **Step 1: Write the models, request types, and guards**
+
+Create `common/models/capture.ts`:
+
+```ts
+import type { unconfirmedLaps } from '../../backend/database/schema'
+import type { Session } from './session'
+import type { Track } from './track'
+import type { User } from './user'
+
+export const CAPTURE_CONTRACT_VERSION = 1
+
+export type CaptureSlotResult = {
+  slot: number
+  bestTimeMs: number
+}
+
+export type CaptureHeatPayload = {
+  contractVersion: number
+  heatId: string
+  mapUid: string
+  mapName: string
+  mapAuthor?: string
+  playerCount: number
+  results: CaptureSlotResult[]
+  serverTime?: number
+}
+
+export type UnconfirmedLap = typeof unconfirmedLaps.$inferSelect
+
+export type UnconfirmedRound = {
+  heatId: string
+  session: Session['id']
+  track: Track['id']
+  playerCount: number
+  createdAt: Date
+  laps: { slot: number; duration: number }[]
+}
+
+export type CaptureState = {
+  activeSessionId: Session['id'] | null
+}
+
+export type CaptureAssignment = {
+  slot: number
+  user: User['id']
+}
+
+export type ConfirmCaptureRequest = {
+  type: 'ConfirmCaptureRequest'
+  heatId: string
+  assignments: CaptureAssignment[]
+}
+
+export function isConfirmCaptureRequest(
+  data: any
+): data is ConfirmCaptureRequest {
+  if (typeof data !== 'object' || data === null) return false
+  return (
+    data.type === 'ConfirmCaptureRequest' &&
+    typeof data.heatId === 'string' &&
+    Array.isArray(data.assignments)
+  )
+}
+
+export type DiscardCaptureRequest = {
+  type: 'DiscardCaptureRequest'
+  heatId: string
+}
+
+export function isDiscardCaptureRequest(
+  data: any
+): data is DiscardCaptureRequest {
+  if (typeof data !== 'object' || data === null) return false
+  return data.type === 'DiscardCaptureRequest' && typeof data.heatId === 'string'
+}
+
+export type SetActiveSessionRequest = {
+  type: 'SetActiveSessionRequest'
+  sessionId: Session['id'] | null
+}
+
+export function isSetActiveSessionRequest(
+  data: any
+): data is SetActiveSessionRequest {
+  if (typeof data !== 'object' || data === null) return false
+  return (
+    data.type === 'SetActiveSessionRequest' &&
+    (typeof data.sessionId === 'string' || data.sessionId === null)
+  )
+}
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `npm run check`
+Expected: passes.
+
+```bash
+git add common/models/capture.ts
+git commit -m "feat(models): add capture DTOs and request guards"
+```
+
+---
+
+## Task 3: Pure capture logic (TDD)
+
+**Files:**
+- Create: `backend/src/managers/capture.logic.ts`
+- Test: `backend/src/managers/capture.logic.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/src/managers/capture.logic.spec.ts`:
+
+```ts
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  isHeatPayload,
+  templateFor,
+  winningSlot,
+  validateAssignments,
+} from './capture.logic'
+
+const validPayload = {
+  contractVersion: 1,
+  heatId: 'h1',
+  mapUid: 'map-uid',
+  mapName: 'My Map',
+  playerCount: 2,
+  results: [
+    { slot: 1, bestTimeMs: 42300 },
+    { slot: 2, bestTimeMs: 45100 },
+  ],
+}
+
+test('isHeatPayload accepts a valid payload', () => {
+  assert.equal(isHeatPayload(validPayload), true)
+})
+
+test('isHeatPayload rejects missing results', () => {
+  assert.equal(isHeatPayload({ ...validPayload, results: undefined }), false)
+})
+
+test('isHeatPayload rejects a non-numeric time', () => {
+  assert.equal(
+    isHeatPayload({ ...validPayload, results: [{ slot: 1, bestTimeMs: 'x' }] }),
+    false
+  )
+})
+
+test('templateFor maps player counts', () => {
+  assert.equal(templateFor(1), 'solo')
+  assert.equal(templateFor(2), 'duel')
+  assert.equal(templateFor(3), null)
+})
+
+test('winningSlot returns the faster slot', () => {
+  assert.equal(winningSlot([
+    { slot: 1, duration: 45100 },
+    { slot: 2, duration: 42300 },
+  ]), 2)
+})
+
+test('winningSlot returns null on a tie', () => {
+  assert.equal(winningSlot([
+    { slot: 1, duration: 42300 },
+    { slot: 2, duration: 42300 },
+  ]), null)
+})
+
+test('validateAssignments requires one per slot and distinct users for duels', () => {
+  const slots = [1, 2]
+  assert.equal(
+    validateAssignments(slots, [
+      { slot: 1, user: 'a' },
+      { slot: 2, user: 'b' },
+    ]),
+    null
+  )
+  assert.equal(
+    typeof validateAssignments(slots, [{ slot: 1, user: 'a' }]),
+    'string'
+  )
+  assert.equal(
+    typeof validateAssignments(slots, [
+      { slot: 1, user: 'a' },
+      { slot: 2, user: 'a' },
+    ]),
+    'string'
+  )
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx tsx --test backend/src/managers/capture.logic.spec.ts`
+Expected: FAIL — `Cannot find module './capture.logic'`.
+
+- [ ] **Step 3: Implement the logic**
+
+Create `backend/src/managers/capture.logic.ts`:
+
+```ts
+import type {
+  CaptureAssignment,
+  CaptureHeatPayload,
+} from '@common/models/capture'
+
+export function isHeatPayload(data: any): data is CaptureHeatPayload {
+  if (typeof data !== 'object' || data === null) return false
+  if (typeof data.heatId !== 'string' || data.heatId.length === 0) return false
+  if (typeof data.mapUid !== 'string' || data.mapUid.length === 0) return false
+  if (typeof data.mapName !== 'string') return false
+  if (typeof data.playerCount !== 'number') return false
+  if (!Array.isArray(data.results) || data.results.length === 0) return false
+  return data.results.every(
+    (r: any) =>
+      typeof r === 'object' &&
+      r !== null &&
+      typeof r.slot === 'number' &&
+      typeof r.bestTimeMs === 'number' &&
+      r.bestTimeMs > 0
+  )
+}
+
+export function templateFor(playerCount: number): 'solo' | 'duel' | null {
+  if (playerCount === 1) return 'solo'
+  if (playerCount === 2) return 'duel'
+  return null
+}
+
+export function winningSlot(
+  laps: { slot: number; duration: number }[]
+): number | null {
+  if (laps.length < 2) return laps[0]?.slot ?? null
+  const sorted = [...laps].sort((a, b) => a.duration - b.duration)
+  if (sorted[0].duration === sorted[1].duration) return null
+  return sorted[0].slot
+}
+
+export function validateAssignments(
+  slots: number[],
+  assignments: CaptureAssignment[]
+): string | null {
+  for (const slot of slots) {
+    const found = assignments.find(a => a.slot === slot)
+    if (!found || typeof found.user !== 'string' || found.user.length === 0) {
+      return `Mangler spiller for plass ${slot}`
+    }
+  }
+  const users = assignments.map(a => a.user)
+  if (new Set(users).size !== users.length) {
+    return 'Samme spiller kan ikke stå på begge plassene'
+  }
+  return null
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx tsx --test backend/src/managers/capture.logic.spec.ts`
+Expected: `# pass 7`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/managers/capture.logic.ts backend/src/managers/capture.logic.spec.ts
+git commit -m "feat(capture): pure logic for payload validation, winner, assignments"
+```
+
+---
+
+## Task 4: Capture store — ingest + fetch (TDD)
+
+**Files:**
+- Create: `backend/src/managers/capture.store.ts`
+- Test: `backend/src/managers/capture.store.spec.ts`
+
+The store takes a `db` argument so tests can pass an in-memory database — no server import.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/src/managers/capture.store.spec.ts`:
+
+```ts
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import * as schema from '../../database/schema'
+import { sessions } from '../../database/schema'
+import { getUnconfirmedRounds, ingestHeat } from './capture.store'
+
+type Db = ReturnType<typeof drizzle<typeof schema>>
+
+let db: Db
+let sessionId: string
+
+beforeEach(async () => {
+  const sqlite = new Database(':memory:')
+  db = drizzle(sqlite, { schema })
+  migrate(db, { migrationsFolder: 'drizzle' })
+  const [s] = await db
+    .insert(sessions)
+    .values({ name: 'Test', date: new Date() })
+    .returning()
+  sessionId = s.id
+})
+
+const payload = {
+  contractVersion: 1,
+  heatId: 'heat-1',
+  mapUid: 'uid-1',
+  mapName: 'Map One',
+  playerCount: 2,
+  results: [
+    { slot: 1, bestTimeMs: 42300 },
+    { slot: 2, bestTimeMs: 45100 },
+  ],
+}
+
+test('ingestHeat creates a track and two laps, grouped into one round', async () => {
+  await ingestHeat(db, payload, sessionId)
+  const rounds = await getUnconfirmedRounds(db)
+  assert.equal(rounds.length, 1)
+  assert.equal(rounds[0].heatId, 'heat-1')
+  assert.equal(rounds[0].playerCount, 2)
+  assert.equal(rounds[0].laps.length, 2)
+  const tracks = await db.select().from(schema.tracks)
+  assert.equal(tracks.length, 1)
+  assert.equal(tracks[0].mapUid, 'uid-1')
+})
+
+test('ingestHeat reuses an existing track for the same mapUid', async () => {
+  await ingestHeat(db, payload, sessionId)
+  await ingestHeat(db, { ...payload, heatId: 'heat-2' }, sessionId)
+  const tracks = await db.select().from(schema.tracks)
+  assert.equal(tracks.length, 1)
+})
+
+test('ingestHeat is idempotent on a duplicate heatId', async () => {
+  await ingestHeat(db, payload, sessionId)
+  await ingestHeat(db, payload, sessionId)
+  const rounds = await getUnconfirmedRounds(db)
+  assert.equal(rounds.length, 1)
+  assert.equal(rounds[0].laps.length, 2)
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx tsx --test backend/src/managers/capture.store.spec.ts`
+Expected: FAIL — `Cannot find module './capture.store'`.
+
+- [ ] **Step 3: Implement ingest + fetch**
+
+Create `backend/src/managers/capture.store.ts`:
+
+```ts
+import type {
+  CaptureHeatPayload,
+  UnconfirmedRound,
+} from '@common/models/capture'
+import { and, eq, isNull } from 'drizzle-orm'
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
+import * as schema from '../../database/schema'
+import { tracks, unconfirmedLaps } from '../../database/schema'
+
+type Db = BetterSQLite3Database<typeof schema>
+
+async function resolveTrackId(
+  db: Db,
+  payload: CaptureHeatPayload
+): Promise<string> {
+  const existing = await db.query.tracks.findFirst({
+    where: eq(tracks.mapUid, payload.mapUid),
+  })
+  if (existing) return existing.id
+  const [created] = await db
+    .insert(tracks)
+    .values({
+      mapUid: payload.mapUid,
+      name: payload.mapName,
+      author: payload.mapAuthor ?? null,
+    })
+    .returning()
+  return created.id
+}
+
+export async function ingestHeat(
+  db: Db,
+  payload: CaptureHeatPayload,
+  sessionId: string
+): Promise<void> {
+  const already = await db.query.unconfirmedLaps.findFirst({
+    where: eq(unconfirmedLaps.heatId, payload.heatId),
+  })
+  if (already) return
+
+  const trackId = await resolveTrackId(db, payload)
+
+  await db.insert(unconfirmedLaps).values(
+    payload.results.map(r => ({
+      session: sessionId,
+      track: trackId,
+      heatId: payload.heatId,
+      slot: r.slot,
+      duration: r.bestTimeMs,
+      playerCount: payload.playerCount,
+    }))
+  )
+}
+
+export async function getUnconfirmedRounds(
+  db: Db
+): Promise<UnconfirmedRound[]> {
+  const rows = await db
+    .select()
+    .from(unconfirmedLaps)
+    .where(isNull(unconfirmedLaps.deletedAt))
+
+  const byHeat = new Map<string, UnconfirmedRound>()
+  for (const row of rows) {
+    let round = byHeat.get(row.heatId)
+    if (!round) {
+      round = {
+        heatId: row.heatId,
+        session: row.session,
+        track: row.track,
+        playerCount: row.playerCount,
+        createdAt: row.createdAt,
+        laps: [],
+      }
+      byHeat.set(row.heatId, round)
+    }
+    round.laps.push({ slot: row.slot, duration: row.duration })
+  }
+  return [...byHeat.values()].sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+  )
+}
+
+export async function lapsForHeat(db: Db, heatId: string) {
+  return db
+    .select()
+    .from(unconfirmedLaps)
+    .where(
+      and(eq(unconfirmedLaps.heatId, heatId), isNull(unconfirmedLaps.deletedAt))
+    )
+}
+
+export async function deleteHeat(db: Db, heatId: string): Promise<void> {
+  await db.delete(unconfirmedLaps).where(eq(unconfirmedLaps.heatId, heatId))
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx tsx --test backend/src/managers/capture.store.spec.ts`
+Expected: `# pass 3`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/managers/capture.store.ts backend/src/managers/capture.store.spec.ts
+git commit -m "feat(capture): store ingest + unconfirmed-round fetch with idempotency"
+```
+
+---
+
+## Task 5: Capture store — confirm + discard (TDD)
+
+**Files:**
+- Modify: `backend/src/managers/capture.store.ts`
+- Modify: `backend/src/managers/capture.store.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these to the **top import block** of `backend/src/managers/capture.store.spec.ts` (prettier organize-imports requires imports at the top):
+
+```ts
+import { matches, timeEntries, users } from '../../database/schema'
+import { confirmCapture, discardCapture } from './capture.store'
+```
+
+Then append the helper + tests to the end of the spec file:
+
+```ts
+async function makeUser(db: Db, name: string): Promise<string> {
+  const [u] = await db
+    .insert(users)
+    .values({
+      email: `${name}@x.no`,
+      firstName: name,
+      passwordHash: Buffer.from('x'),
+    })
+    .returning()
+  return u.id
+}
+
+test('confirmCapture writes two auto time entries + a completed match, deletes laps', async () => {
+  await ingestHeat(db, payload, sessionId)
+  const a = await makeUser(db, 'alice')
+  const b = await makeUser(db, 'bob')
+
+  await confirmCapture(db, 'heat-1', [
+    { slot: 1, user: a },
+    { slot: 2, user: b },
+  ])
+
+  const entries = await db.select().from(timeEntries)
+  assert.equal(entries.length, 2)
+  assert.equal(entries.every(e => e.source === 'auto'), true)
+  assert.equal(entries.every(e => e.session === sessionId), true)
+
+  const [match] = await db.select().from(matches)
+  assert.equal(match.status, 'completed')
+  assert.equal(match.winner, a) // slot 1 was faster (42300 < 45100)
+
+  const rounds = await getUnconfirmedRounds(db)
+  assert.equal(rounds.length, 0)
+})
+
+test('confirmCapture for a solo round writes one entry and no match', async () => {
+  await ingestHeat(
+    db,
+    {
+      ...payload,
+      heatId: 'solo-1',
+      playerCount: 1,
+      results: [{ slot: 1, bestTimeMs: 40000 }],
+    },
+    sessionId
+  )
+  const a = await makeUser(db, 'solo')
+  await confirmCapture(db, 'solo-1', [{ slot: 1, user: a }])
+  assert.equal((await db.select().from(timeEntries)).length, 1)
+  assert.equal((await db.select().from(matches)).length, 0)
+})
+
+test('discardCapture removes laps without writing entries', async () => {
+  await ingestHeat(db, payload, sessionId)
+  await discardCapture(db, 'heat-1')
+  assert.equal((await getUnconfirmedRounds(db)).length, 0)
+  assert.equal((await db.select().from(timeEntries)).length, 0)
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx tsx --test backend/src/managers/capture.store.spec.ts`
+Expected: FAIL — `confirmCapture` / `discardCapture` not exported.
+
+- [ ] **Step 3: Implement confirm + discard**
+
+Add these to the **top import block** of `backend/src/managers/capture.store.ts` (merge with the existing imports; do not append at the bottom — organize-imports will reject that):
+
+```ts
+import type { CaptureAssignment as Assignment } from '@common/models/capture'
+import { matches, timeEntries } from '../../database/schema'
+import { validateAssignments, winningSlot } from './capture.logic'
+```
+
+Then append these functions to the end of the file (`winningSlot`/`validateAssignments` come from `capture.logic.ts`):
+
+```ts
+export async function confirmCapture(
+  db: Db,
+  heatId: string,
+  assignments: Assignment[]
+): Promise<void> {
+  const laps = await lapsForHeat(db, heatId)
+  if (laps.length === 0) throw new Error('Fant ingen ubekrefta runde')
+
+  const slots = laps.map(l => l.slot)
+  const problem = validateAssignments(slots, assignments)
+  if (problem) throw new Error(problem)
+
+  const sessionId = laps[0].session
+  const trackId = laps[0].track
+
+  const entryValues = laps.map(lap => {
+    const assignment = assignments.find(a => a.slot === lap.slot)!
+    return {
+      user: assignment.user,
+      track: trackId,
+      session: sessionId,
+      duration: lap.duration,
+      source: 'auto' as const,
+    }
+  })
+  await db.insert(timeEntries).values(entryValues)
+
+  if (laps.length === 2) {
+    const winSlot = winningSlot(
+      laps.map(l => ({ slot: l.slot, duration: l.duration }))
+    )
+    const userForSlot = (slot: number) =>
+      assignments.find(a => a.slot === slot)!.user
+    await db.insert(matches).values({
+      user1: userForSlot(laps[0].slot),
+      user2: userForSlot(laps[1].slot),
+      track: trackId,
+      session: sessionId,
+      winner: winSlot === null ? null : userForSlot(winSlot),
+      status: 'completed',
+    })
+  }
+
+  await deleteHeat(db, heatId)
+}
+
+export async function discardCapture(db: Db, heatId: string): Promise<void> {
+  await deleteHeat(db, heatId)
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx tsx --test backend/src/managers/capture.store.spec.ts`
+Expected: `# pass 6`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/managers/capture.store.ts backend/src/managers/capture.store.spec.ts
+git commit -m "feat(capture): confirm writes entries + match, discard removes laps"
+```
+
+---
+
+## Task 6: Socket.IO event types
+
+**Files:**
+- Modify: `common/models/socket.io.ts`
+
+- [ ] **Step 1: Import the capture types**
+
+At the top of `common/models/socket.io.ts`, add to the import block:
+
+```ts
+import type {
+  CaptureState,
+  ConfirmCaptureRequest,
+  DiscardCaptureRequest,
+  SetActiveSessionRequest,
+  UnconfirmedRound,
+} from './capture'
+```
+
+- [ ] **Step 2: Add server→client events**
+
+In `ServerToClientEvents`, add:
+
+```ts
+  all_unconfirmed_rounds: (r: UnconfirmedRound[]) => void
+  capture_state: (r: CaptureState) => void
+```
+
+- [ ] **Step 3: Add client→server events**
+
+In `ClientToServerEvents`, add:
+
+```ts
+  set_active_session: (
+    r: SetActiveSessionRequest,
+    callback: (r: SuccessResponse | ErrorResponse) => void
+  ) => void
+  confirm_capture: (
+    r: ConfirmCaptureRequest,
+    callback: (r: SuccessResponse | ErrorResponse) => void
+  ) => void
+  discard_capture: (
+    r: DiscardCaptureRequest,
+    callback: (r: SuccessResponse | ErrorResponse) => void
+  ) => void
+```
+
+- [ ] **Step 4: Typecheck + commit**
+
+Run: `npm run check`
+Expected: passes.
+
+```bash
+git add common/models/socket.io.ts
+git commit -m "feat(socket): capture event types"
+```
+
+---
+
+## Task 7: Capture manager (handlers + active-session state)
+
+**Files:**
+- Create: `backend/src/managers/capture.manager.ts`
+
+This module imports `db` and `broadcast` (so it is NOT unit-tested; its logic is already covered by Tasks 3–5).
+
+- [ ] **Step 1: Implement the manager**
+
+Create `backend/src/managers/capture.manager.ts`:
+
+```ts
+import {
+  isConfirmCaptureRequest,
+  isDiscardCaptureRequest,
+  isSetActiveSessionRequest,
+  type CaptureState,
+  type UnconfirmedRound,
+} from '@common/models/capture'
+import type { EventReq, EventRes } from '@common/models/socket.io'
+import loc from '../../../frontend/lib/locales'
+import db from '../../database/database'
+import { broadcast, type TypedSocket } from '../server'
+import AuthManager from './auth.manager'
+import { isHeatPayload } from './capture.logic'
+import {
+  confirmCapture,
+  discardCapture,
+  getUnconfirmedRounds,
+  ingestHeat,
+} from './capture.store'
+import RatingManager from './rating.manager'
+
+export default class CaptureManager {
+  private static activeSessionId: string | null = null
+
+  static getCaptureState(): CaptureState {
+    return { activeSessionId: CaptureManager.activeSessionId }
+  }
+
+  static async getUnconfirmedRounds(): Promise<UnconfirmedRound[]> {
+    return getUnconfirmedRounds(db)
+  }
+
+  // Called by the HTTP route. Returns true if the heat was stored, false if ignored.
+  static async ingestHeat(body: unknown): Promise<boolean> {
+    if (!isHeatPayload(body)) {
+      throw new Error(loc.no.error.messages.invalid_request('CaptureHeatPayload'))
+    }
+    if (!CaptureManager.activeSessionId) {
+      console.debug(
+        new Date().toISOString(),
+        'Capture ignored — no active session',
+        body.heatId
+      )
+      return false
+    }
+    await ingestHeat(db, body, CaptureManager.activeSessionId)
+    broadcast('all_unconfirmed_rounds', await getUnconfirmedRounds(db))
+    return true
+  }
+
+  static async onSetActiveSession(
+    socket: TypedSocket,
+    request: EventReq<'set_active_session'>
+  ): Promise<EventRes<'set_active_session'>> {
+    if (!isSetActiveSessionRequest(request)) {
+      throw new Error(
+        loc.no.error.messages.invalid_request('SetActiveSessionRequest')
+      )
+    }
+    await AuthManager.checkAuth(socket, ['admin', 'moderator'])
+    CaptureManager.activeSessionId = request.sessionId
+    broadcast('capture_state', CaptureManager.getCaptureState())
+    return { success: true }
+  }
+
+  static async onConfirmCapture(
+    socket: TypedSocket,
+    request: EventReq<'confirm_capture'>
+  ): Promise<EventRes<'confirm_capture'>> {
+    if (!isConfirmCaptureRequest(request)) {
+      throw new Error(
+        loc.no.error.messages.invalid_request('ConfirmCaptureRequest')
+      )
+    }
+    await AuthManager.checkAuth(socket, ['admin', 'moderator'])
+    await confirmCapture(db, request.heatId, request.assignments)
+
+    await RatingManager.recalculate()
+    broadcast('all_unconfirmed_rounds', await getUnconfirmedRounds(db))
+    broadcast('all_time_entries', await TimeEntryFeed())
+    broadcast('all_matches', await MatchFeed())
+    broadcast('all_rankings', await RatingManager.onGetRatings())
+    return { success: true }
+  }
+
+  static async onDiscardCapture(
+    socket: TypedSocket,
+    request: EventReq<'discard_capture'>
+  ): Promise<EventRes<'discard_capture'>> {
+    if (!isDiscardCaptureRequest(request)) {
+      throw new Error(
+        loc.no.error.messages.invalid_request('DiscardCaptureRequest')
+      )
+    }
+    await AuthManager.checkAuth(socket, ['admin', 'moderator'])
+    await discardCapture(db, request.heatId)
+    broadcast('all_unconfirmed_rounds', await getUnconfirmedRounds(db))
+    return { success: true }
+  }
+}
+
+async function TimeEntryFeed() {
+  const { default: TimeEntryManager } = await import('./timeEntry.manager')
+  return TimeEntryManager.getAllTimeEntries()
+}
+
+async function MatchFeed() {
+  const { default: MatchManager } = await import('./match.manager')
+  return MatchManager.getAllMatches()
+}
+```
+
+(The dynamic `import()` helpers avoid a circular import between `capture.manager` and `timeEntry.manager`/`match.manager`, which both import `broadcast` from `server.ts`.)
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `npm run check`
+Expected: passes.
+
+```bash
+git add backend/src/managers/capture.manager.ts
+git commit -m "feat(capture): manager handlers + active-session state"
+```
+
+---
+
+## Task 8: HTTP route + socket wiring + env
+
+**Files:**
+- Modify: `backend/src/server.ts`
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add `CAPTURE_TOKEN` + the ingest route**
+
+In `backend/src/server.ts`, add `CaptureManager` to the manager imports:
+
+```ts
+import CaptureManager from './managers/capture.manager'
+```
+
+After the `const ORIGIN = ...` line, add:
+
+```ts
+const CAPTURE_TOKEN = process.env.CAPTURE_TOKEN
+```
+
+After the existing `app.get('/api/sessions/calendar.ics', ...)` block, add:
+
+```ts
+app.post('/api/capture/heat', express.json(), async (req, res) => {
+  if (!CAPTURE_TOKEN) {
+    res.status(503).json({ success: false, message: 'Capture disabled' })
+    return
+  }
+  const auth = req.header('authorization')
+  if (auth !== `Bearer ${CAPTURE_TOKEN}`) {
+    res.status(401).json({ success: false, message: 'Unauthorized' })
+    return
+  }
+  try {
+    const stored = await CaptureManager.ingestHeat(req.body)
+    res.status(200).json({ success: true, stored })
+  } catch (e) {
+    res.status(400).json({ success: false, message: (e as Error).message })
+  }
+})
+```
+
+- [ ] **Step 2: Emit capture state on connect**
+
+Inside `Connect(s)`, after the existing `s.emit('all_tournaments', ...)` line, add:
+
+```ts
+  s.emit('capture_state', CaptureManager.getCaptureState())
+  s.emit('all_unconfirmed_rounds', await CaptureManager.getUnconfirmedRounds())
+```
+
+- [ ] **Step 3: Wire the client→server handlers**
+
+After the existing `setup(s, 'get_tournament_preview', ...)` line, add:
+
+```ts
+  setup(s, 'set_active_session', CaptureManager.onSetActiveSession)
+  setup(s, 'confirm_capture', CaptureManager.onConfirmCapture)
+  setup(s, 'discard_capture', CaptureManager.onDiscardCapture)
+```
+
+- [ ] **Step 4: Update `.env.example`**
+
+Replace the contents of `.env.example` with:
+
+```
+SECRET="<jwt-signing-secret>"
+CAPTURE_TOKEN="<shared-secret-for-the-openplanet-plugin>"
+```
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `npm run check`
+Expected: passes.
+
+```bash
+git add backend/src/server.ts .env.example
+git commit -m "feat(capture): /api/capture/heat route + socket wiring + CAPTURE_TOKEN"
+```
+
+---
+
+## Task 9: Cross-repo contract doc
+
+**Files:**
+- Create: `docs/autocapture/capture-contract.md`
+
+- [ ] **Step 1: Write the contract**
+
+Create `docs/autocapture/capture-contract.md`:
+
+```markdown
+# Capture HTTP contract (v1)
+
+The Openplanet plugin (separate repo) POSTs finished-heat results to Chugmania.
+
+## Endpoint
+`POST /api/capture/heat`
+
+## Auth
+Header `Authorization: Bearer <CAPTURE_TOKEN>` — must equal the backend's `CAPTURE_TOKEN` env var.
+If the backend has no `CAPTURE_TOKEN` set, the endpoint returns `503` (feature disabled).
+
+## Body (application/json)
+\`\`\`json
+{
+  "contractVersion": 1,
+  "heatId": "string — stable across retries; idempotency key",
+  "mapUid": "string — TM2020 MapUid",
+  "mapName": "string",
+  "mapAuthor": "string (optional)",
+  "playerCount": 1,
+  "results": [{ "slot": 1, "bestTimeMs": 42300 }],
+  "serverTime": 0
+}
+\`\`\`
+
+- `playerCount` 1 → solo, 2 → 1v1. Other values are logged and discarded.
+- `results` carries one entry per slot with that slot's best finish time for the map visit.
+
+## Responses
+- `200 { success: true, stored: boolean }` — `stored:false` means there was no active session, so the heat was ignored (do NOT retry).
+- `401` — bad/missing token.
+- `400` — malformed payload.
+- `503` — capture disabled (no token configured).
+
+## Idempotency
+Re-POSTing the same `heatId` is a no-op. Retry freely on network failure.
+
+## Versioning
+Bump `contractVersion` on any breaking change; the backend logic for v1 lives in `backend/src/managers/capture.logic.ts`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/autocapture/capture-contract.md
+git commit -m "docs: capture HTTP contract v1"
+```
+
+---
+
+## Task 10: CSV completeness (AdminManager)
+
+**Files:**
+- Modify: `common/models/importCsv.ts`
+- Modify: `backend/src/managers/admin.manager.ts`
+- Modify: `frontend/lib/locales.ts`
+
+- [ ] **Step 1: Add the table to the CSV union**
+
+In `common/models/importCsv.ts`, add `'unconfirmedLaps'` to the `ExportCsvRequest['table']` union (the string-literal union of table names).
+
+- [ ] **Step 2: Register the table in AdminManager**
+
+In `backend/src/managers/admin.manager.ts`, import `unconfirmedLaps` from the schema, then add to both objects:
+
+In `EXCLUDED_COL_EXPORT`: `unconfirmedLaps: new Set(),`
+In `TABLE_MAP`: `unconfirmedLaps: unconfirmedLaps,`
+
+- [ ] **Step 3: Add the locale label**
+
+In `frontend/lib/locales.ts`, in `no.admin.tables`, add: `unconfirmedLaps: 'Ubekrefta runder',`
+
+- [ ] **Step 4: Typecheck + commit**
+
+Run: `npm run check`
+Expected: passes (the `satisfies Record<ExportCsvRequest['table'], ...>` constraints now resolve).
+
+```bash
+git add common/models/importCsv.ts backend/src/managers/admin.manager.ts frontend/lib/locales.ts
+git commit -m "feat(admin): include unconfirmed_laps in CSV import/export"
+```
+
+---
+
+## Task 11: Frontend data wiring
+
+**Files:**
+- Modify: `frontend/contexts/DataContext.tsx`
+
+- [ ] **Step 1: Add state, listeners, and context values**
+
+In `frontend/contexts/DataContext.tsx`:
+
+1. Import the types: `import type { CaptureState, UnconfirmedRound } from '@common/models/capture'`.
+2. Add state near the other `useState` calls:
+
+```ts
+const [unconfirmedRounds, setUnconfirmedRounds] = useState<UnconfirmedRound[]>([])
+const [captureState, setCaptureState] = useState<CaptureState>({ activeSessionId: null })
+```
+
+3. In the `useEffect` that registers `socket.on(...)`, add:
+
+```ts
+socket.on('all_unconfirmed_rounds', data => { setUnconfirmedRounds(data) })
+socket.on('capture_state', data => { setCaptureState(data) })
+```
+
+and in its cleanup `return () => { ... }`:
+
+```ts
+socket.off('all_unconfirmed_rounds')
+socket.off('capture_state')
+```
+
+4. Add `unconfirmedRounds` and `captureState` to both the context value object and the `useData()` return type (the non-loading branch of the discriminated union).
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `npm run check`
+Expected: passes.
+
+```bash
+git add frontend/contexts/DataContext.tsx
+git commit -m "feat(capture): frontend store for unconfirmed rounds + capture state"
+```
+
+---
+
+## Task 12: Locale strings for the capture UI
+
+**Files:**
+- Modify: `frontend/lib/locales.ts`
+
+- [ ] **Step 1: Add a `capture` block**
+
+In `frontend/lib/locales.ts`, add to the `no` object (sibling of `timeEntry`):
+
+```ts
+  capture: {
+    unconfirmedTitle: 'Ubekrefta runder',
+    activate: 'Aktiver registrering',
+    deactivate: 'Stopp registrering',
+    active: 'Registrering aktiv',
+    assignTitle: 'Hvem kjørte?',
+    selectPlayer: 'Velg spiller',
+    swap: 'Bytt om',
+    confirm: 'Bekreft',
+    discard: 'Forkast',
+    confirmRequest: {
+      loading: 'Bekrefter runde...',
+      success: 'Runde registrert',
+      error: (err: Error) => `Feil ved registrering: ${err.message}`,
+    },
+    discardRequest: {
+      loading: 'Forkaster runde...',
+      success: 'Runde forkastet',
+      error: (err: Error) => `Feil ved forkasting: ${err.message}`,
+    },
+    activateRequest: {
+      loading: 'Endrer registrering...',
+      success: 'Registrering oppdatert',
+      error: (err: Error) => `Feil: ${err.message}`,
+    },
+  },
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `npm run check`
+Expected: passes.
+
+```bash
+git add frontend/lib/locales.ts
+git commit -m "feat(capture): locale strings"
+```
+
+---
+
+## Task 13: ConfirmRoundDialog component
+
+**Files:**
+- Create: `frontend/components/capture/ConfirmRoundDialog.tsx`
+
+- [ ] **Step 1: Implement the dialog**
+
+Create `frontend/components/capture/ConfirmRoundDialog.tsx`:
+
+```tsx
+import type {
+  CaptureAssignment,
+  UnconfirmedRound,
+} from '@common/models/capture'
+import { formatDuration } from '@common/utils/time'
+import { useState } from 'react'
+import { useConnection } from '../../contexts/ConnectionContext'
+import { useData } from '../../contexts/DataContext'
+import { toast } from 'sonner'
+import loc from '../../lib/locales'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { NativeSelect } from '../ui/native-select'
+import { Button } from '../ui/button'
+
+type Props = {
+  round: UnconfirmedRound | null
+  onClose: () => void
+}
+
+export function ConfirmRoundDialog({ round, onClose }: Props) {
+  const { socket } = useConnection()
+  const { users, tracks } = useData()
+  const [picks, setPicks] = useState<Record<number, string>>({})
+
+  if (!round) return null
+
+  const track = tracks.find(t => t.id === round.track)
+  const sortedLaps = [...round.laps].sort((a, b) => a.slot - b.slot)
+
+  function setPick(slot: number, user: string) {
+    setPicks(prev => ({ ...prev, [slot]: user }))
+  }
+
+  function swap() {
+    if (sortedLaps.length !== 2) return
+    const [s1, s2] = sortedLaps
+    setPicks(prev => ({ ...prev, [s1.slot]: prev[s2.slot] ?? '', [s2.slot]: prev[s1.slot] ?? '' }))
+  }
+
+  function confirm() {
+    const assignments: CaptureAssignment[] = sortedLaps.map(l => ({
+      slot: l.slot,
+      user: picks[l.slot],
+    }))
+    toast.promise(
+      socket
+        .emitWithAck('confirm_capture', {
+          type: 'ConfirmCaptureRequest',
+          heatId: round!.heatId,
+          assignments,
+        })
+        .then(r => {
+          if (!r.success) throw new Error(r.message)
+        }),
+      loc.no.capture.confirmRequest
+    )
+    onClose()
+  }
+
+  function discard() {
+    toast.promise(
+      socket
+        .emitWithAck('discard_capture', {
+          type: 'DiscardCaptureRequest',
+          heatId: round!.heatId,
+        })
+        .then(r => {
+          if (!r.success) throw new Error(r.message)
+        }),
+      loc.no.capture.discardRequest
+    )
+    onClose()
+  }
+
+  return (
+    <Dialog open={!!round} onOpenChange={o => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{loc.no.capture.assignTitle}</DialogTitle>
+        </DialogHeader>
+        <p className='text-muted-foreground text-sm'>{track?.name ?? track?.mapUid}</p>
+        <div className='flex flex-col gap-3'>
+          {sortedLaps.map(lap => (
+            <div key={lap.slot} className='flex items-center justify-between gap-3'>
+              <span className='font-mono tabular-nums'>{formatDuration(lap.duration)}</span>
+              <NativeSelect
+                value={picks[lap.slot] ?? ''}
+                onChange={e => setPick(lap.slot, e.target.value)}
+              >
+                <option value='' disabled>
+                  {loc.no.capture.selectPlayer}
+                </option>
+                {users.map(u => (
+                  <option key={u.id} value={u.id}>
+                    {u.firstName} {u.lastName ?? ''}
+                  </option>
+                ))}
+              </NativeSelect>
+            </div>
+          ))}
+        </div>
+        <DialogFooter className='flex-row justify-between'>
+          <Button variant='ghost' onClick={discard}>
+            {loc.no.capture.discard}
+          </Button>
+          <div className='flex gap-2'>
+            {sortedLaps.length === 2 && (
+              <Button variant='outline' onClick={swap}>
+                {loc.no.capture.swap}
+              </Button>
+            )}
+            <Button onClick={confirm}>{loc.no.capture.confirm}</Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+> **Verify during implementation:** confirm the import aliases (`@frontend/*`, `@common/*`) and the `formatDuration` export name in `common/utils/time.ts` match the repo; adjust the imports to the actual paths used by neighbouring components (e.g. `TimeEntryRow.tsx`). The dialog/select/button component paths are confirmed in the grounding notes.
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `npm run check`
+Expected: passes.
+
+```bash
+git add frontend/components/capture/ConfirmRoundDialog.tsx
+git commit -m "feat(capture): confirm-round dialog (solo + 1v1 with swap)"
+```
+
+---
+
+## Task 14: UnconfirmedRoundsTable + ActiveSessionControl
+
+**Files:**
+- Create: `frontend/components/capture/UnconfirmedRoundsTable.tsx`
+- Create: `frontend/components/capture/ActiveSessionControl.tsx`
+
+- [ ] **Step 1: Faded table**
+
+Create `frontend/components/capture/UnconfirmedRoundsTable.tsx`:
+
+```tsx
+import type { UnconfirmedRound } from '@common/models/capture'
+import { formatDuration } from '@common/utils/time'
+import { useState } from 'react'
+import { useData } from '../../contexts/DataContext'
+import loc from '../../lib/locales'
+import { ConfirmRoundDialog } from './ConfirmRoundDialog'
+
+export function UnconfirmedRoundsTable({ sessionId }: { sessionId: string }) {
+  const { unconfirmedRounds, tracks } = useData()
+  const [selected, setSelected] = useState<UnconfirmedRound | null>(null)
+
+  const rounds = unconfirmedRounds.filter(r => r.session === sessionId)
+  if (rounds.length === 0) return null
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <h3 className='text-muted-foreground text-sm font-semibold uppercase'>
+        {loc.no.capture.unconfirmedTitle}
+      </h3>
+      <div className='bg-background-secondary flex flex-col rounded-sm opacity-60'>
+        {rounds.flatMap(round =>
+          [...round.laps]
+            .sort((a, b) => a.slot - b.slot)
+            .map(lap => {
+              const track = tracks.find(t => t.id === round.track)
+              return (
+                <button
+                  key={`${round.heatId}-${lap.slot}`}
+                  onClick={() => setSelected(round)}
+                  className='flex items-center justify-between px-4 py-3 text-left hover:opacity-100'
+                >
+                  <span className='text-muted-foreground'>
+                    {track?.name ?? track?.mapUid}
+                  </span>
+                  <span className='font-mono tabular-nums'>
+                    {formatDuration(lap.duration)}
+                  </span>
+                </button>
+              )
+            })
+        )}
+      </div>
+      <ConfirmRoundDialog round={selected} onClose={() => setSelected(null)} />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Active-session control**
+
+Create `frontend/components/capture/ActiveSessionControl.tsx`:
+
+```tsx
+import { toast } from 'sonner'
+import { useConnection } from '../../contexts/ConnectionContext'
+import { useData } from '../../contexts/DataContext'
+import loc from '../../lib/locales'
+import { Button } from '../ui/button'
+
+export function ActiveSessionControl({ sessionId }: { sessionId: string }) {
+  const { socket } = useConnection()
+  const { captureState } = useData()
+  const isActive = captureState.activeSessionId === sessionId
+
+  function setActive(active: boolean) {
+    toast.promise(
+      socket
+        .emitWithAck('set_active_session', {
+          type: 'SetActiveSessionRequest',
+          sessionId: active ? sessionId : null,
+        })
+        .then(r => {
+          if (!r.success) throw new Error(r.message)
+        }),
+      loc.no.capture.activateRequest
+    )
+  }
+
+  return (
+    <Button
+      variant={isActive ? 'default' : 'outline'}
+      onClick={() => setActive(!isActive)}
+    >
+      {isActive ? loc.no.capture.deactivate : loc.no.capture.activate}
+    </Button>
+  )
+}
+```
+
+- [ ] **Step 3: Typecheck + commit**
+
+Run: `npm run check`
+Expected: passes.
+
+```bash
+git add frontend/components/capture/UnconfirmedRoundsTable.tsx frontend/components/capture/ActiveSessionControl.tsx
+git commit -m "feat(capture): faded unconfirmed-rounds table + active-session control"
+```
+
+---
+
+## Task 15: Wire the capture UI into the session page
+
+**Files:**
+- Modify: `frontend/app/pages/SessionPage.tsx`
+
+- [ ] **Step 1: Render the control + table for admins/mods**
+
+In `frontend/app/pages/SessionPage.tsx`:
+
+1. Add imports:
+
+```ts
+import { ActiveSessionControl } from '../../components/capture/ActiveSessionControl'
+import { UnconfirmedRoundsTable } from '../../components/capture/UnconfirmedRoundsTable'
+```
+
+2. Determine moderator status from the existing logged-in user (mirror how the page already reads `loggedInUser`/`isLoggedIn`): `const isModerator = isLoggedIn && loggedInUser.role !== 'user'`.
+
+3. Just above the `{tracks.map(track => (<TrackLeaderboard .../>))}` block, add:
+
+```tsx
+{isModerator && (
+  <div className='flex flex-col gap-4'>
+    <ActiveSessionControl sessionId={session.id} />
+    <UnconfirmedRoundsTable sessionId={session.id} />
+  </div>
+)}
+```
+
+- [ ] **Step 2: Build + typecheck**
+
+Run: `npm run check`
+Expected: passes.
+
+- [ ] **Step 3: Manual smoke in the running app**
+
+Run: `npm run dev`, log in as an admin, open a session, click **Aktiver registrering**. Confirm the button toggles to **Stopp registrering** (proves `set_active_session` + `capture_state` round-trips).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/app/pages/SessionPage.tsx
+git commit -m "feat(capture): show active-session control + unconfirmed rounds on session page"
+```
+
+---
+
+## Task 16: Mock-plugin script + full manual E2E
+
+**Files:**
+- Create: `scripts/mock-plugin.ts`
+
+- [ ] **Step 1: Write the mock plugin**
+
+Create `scripts/mock-plugin.ts`:
+
+```ts
+const url = process.env.CAPTURE_URL ?? 'http://localhost:6996/api/capture/heat'
+const token = process.env.CAPTURE_TOKEN ?? ''
+const playerCount = Number(process.argv[2] ?? '2')
+
+const results =
+  playerCount === 1
+    ? [{ slot: 1, bestTimeMs: 41000 }]
+    : [
+        { slot: 1, bestTimeMs: 42300 },
+        { slot: 2, bestTimeMs: 45100 },
+      ]
+
+const body = {
+  contractVersion: 1,
+  heatId: `mock-${Date.now()}`,
+  mapUid: 'mock-map-uid',
+  mapName: 'Mock Map',
+  playerCount,
+  results,
+}
+
+const res = await fetch(url, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+  body: JSON.stringify(body),
+})
+console.log(res.status, await res.json())
+```
+
+- [ ] **Step 2: Run the full manual E2E (T4)**
+
+With `npm run dev` running and `CAPTURE_TOKEN` set in `.env`:
+
+1. Log in as admin, open a session, click **Aktiver registrering**.
+2. 1v1: `CAPTURE_TOKEN=<token> npx tsx scripts/mock-plugin.ts 2` → a faded row pair appears under **Ubekrefta runder** → click it → assign two players → **Bekreft** → two entries on the leaderboard + a completed match; faded rows vanish.
+3. Solo: `... scripts/mock-plugin.ts 1` → one faded row → assign one player → confirms to one leaderboard entry, no match.
+4. Click **Stopp registrering**, POST again → response `{ stored: false }`, no faded row (ignored-when-inactive).
+5. Confirm manual time entry via "Registrer tid" still works unchanged (parallel-operation check).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/mock-plugin.ts
+git commit -m "chore(capture): mock-plugin script for manual E2E"
+```
+
+---
+
+## Task 17: README + finalize PR
+
+- [ ] **Step 1: Document the feature**
+
+Add a short "Auto-capture (Trackmania 2020)" section to `README.md`: what it does, the `CAPTURE_TOKEN` env var, the active-session toggle, and a link to `docs/autocapture/capture-contract.md` and the plugin repo.
+
+- [ ] **Step 2: Full gate**
+
+Run: `npm run check && npm test`
+Expected: check passes; `# pass 16` across the spec files.
+
+- [ ] **Step 3: Commit + open PR**
+
+```bash
+git add README.md
+git commit -m "docs: document Trackmania auto-capture"
+git push -u origin feat/trackmania-autocapture
+gh pr create --fill
+```
+
+(Per the spec: this is a PR to the upstream Chugmania repo; keep it scoped to the capture feature.)
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Run order matters:** Tasks 1→2→3→6 define types others depend on; do not reorder past those.
+- **Reactive contract:** every mutation broadcasts via a `getAll*` fetch helper (already done in the manager). If you add a feed, add the matching `socket.on/off` in `DataContext`.
+- **`amount_l`:** time entries keep the schema default (`0.5`) — auto-capture never sets the drink amount (it is baked into the lap time per the spec).
+- **Role-awareness:** unconfirmed rounds are broadcast to all clients but the UI only renders them for admins/mods, and all mutations are server-side auth-gated. If stricter per-socket filtering is required, that is a follow-up.

--- a/docs/superpowers/plans/2026-06-08-trackmania-openplanet-capture-plugin.md
+++ b/docs/superpowers/plans/2026-06-08-trackmania-openplanet-capture-plugin.md
@@ -1,0 +1,436 @@
+# Trackmania Openplanet Capture Plugin — Implementation Plan (separate repo)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A small Openplanet plugin for Trackmania 2020 that, during a local splitscreen or solo session, captures each player slot's best finish time per map visit and POSTs it to Chugmania's `/api/capture/heat` endpoint.
+
+**Architecture:** AngelScript plugin reading the in-process game state each frame (`GetApp().CurrentPlayground` → `CSmArenaClient.Players` → `CSmScriptPlayer.RaceWaypointTimes`), tracking best finish per slot for the current map, and firing `Net::HttpPost` with a stable `heatId` on map end (plus a manual hotkey). Configuration (capture URL + token) via Openplanet settings.
+
+**Tech Stack:** Openplanet (AngelScript), `Net::HttpRequest`. Runs on the gaming PC. Requires Openplanet **Developer mode** (TM Club Access ~$20/yr) to run unsigned, or plugin signing.
+
+**Repo:** This is its own repository, NOT part of the Chugmania repo. The only coupling is the contract documented in the Chugmania repo at `docs/autocapture/capture-contract.md` (Plan 1, Task 9).
+
+> **CRITICAL GATE — Task 0 must pass before Tasks 1–5.** The research flagged one genuine unknown: whether `CSmArenaClient.Players` enumerates *both* splitscreen slots in an offline local session, and exactly which members carry the slot index and finish time. Task 0 verifies this empirically and records the real field names. **If Task 0 shows only the primary player is visible, STOP** and switch to the replay-file-watcher fallback (see Appendix A) before writing the real plugin. Treat the API member names in Tasks 2–4 as "best known" until Task 0 confirms them.
+
+---
+
+## File structure
+
+- `info.toml` — Openplanet plugin manifest.
+- `src/Main.as` — entry points (`Main`, `Update`, `RenderMenu`), lifecycle.
+- `src/Capture.as` — per-slot best-time tracking + heat assembly.
+- `src/Net.as` — HTTP POST with retry.
+- `src/Settings.as` — Openplanet settings (URL, token, hotkey, enabled).
+- `README.md` — install, settings, Developer-mode/signing notes.
+
+---
+
+## Task 0: Feasibility spike (THE GATE)
+
+**Files:**
+- Create: `spike/info.toml`
+- Create: `spike/Main.as`
+
+- [ ] **Step 1: Minimal probe manifest**
+
+Create `spike/info.toml`:
+
+```toml
+[meta]
+name = "Chugmania Capture Spike"
+author = "you"
+category = "Utilities"
+
+[script]
+dependencies = []
+```
+
+- [ ] **Step 2: Probe that prints the player array each finish**
+
+Create `spike/Main.as`:
+
+```angelscript
+void Update(float dt) {
+    auto app = cast<CTrackMania>(GetApp());
+    auto pg = cast<CSmArenaClient>(app.CurrentPlayground);
+    if (pg is null) return;
+
+    print("Players.Length = " + pg.Players.Length);
+    for (uint i = 0; i < pg.Players.Length; i++) {
+        auto player = cast<CSmPlayer>(pg.Players[i]);
+        if (player is null) continue;
+        auto sp = player.ScriptPlayer;
+        string name = player.User !is null ? player.User.Name : "?";
+        uint wpCount = (sp !is null) ? sp.RaceWaypointTimes.Length : 0;
+        string last = wpCount > 0 ? "" + sp.RaceWaypointTimes[wpCount - 1] : "-";
+        print("  slot " + i + " name=" + name + " wpCount=" + wpCount + " lastWp=" + last);
+    }
+}
+```
+
+- [ ] **Step 3: Install Openplanet + run the probe**
+
+Install Openplanet on the gaming PC (Developer mode enabled). Drop the `spike/` folder into `OpenplanetNext/Plugins/`. Launch Trackmania → `LOCAL → LOCAL MULTIPLAYER → SPLITSCREEN`, 2 players, Time Attack, on any map. Open the Openplanet log (`~` / Openplanet → Log).
+
+- [ ] **Step 4: Record the verdict + real field names**
+
+Observe and write down in `spike/FINDINGS.md`:
+- Does `Players.Length` equal **2** during 2-player splitscreen? (the crux)
+- What distinguishes the slots — array index `i`, `player.User.Name`, or another member?
+- After a player crosses the finish, does `RaceWaypointTimes` grow and is the last element the finish time in ms?
+- Repeat for **hotseat** and **solo** (expect `Players.Length` 1).
+- If any cast/member name above is wrong, note the correct one from the log/error (e.g. `ScriptPlayer` may need a different access path).
+
+- [ ] **Step 5: Decision**
+
+- **Both slots visible** → proceed to Task 1; carry the confirmed field names into Tasks 2–4.
+- **Only one slot visible** → STOP. Go to Appendix A (replay-file watcher) and re-plan.
+
+Commit the findings:
+
+```bash
+git add spike/
+git commit -m "spike: verify Openplanet sees both splitscreen slots offline"
+```
+
+---
+
+## Task 1: Plugin scaffold + settings
+
+**Files:**
+- Create: `info.toml`
+- Create: `src/Settings.as`
+- Create: `src/Main.as`
+
+- [ ] **Step 1: Manifest**
+
+Create `info.toml`:
+
+```toml
+[meta]
+name = "Chugmania Capture"
+author = "you"
+category = "Utilities"
+version = "0.1.0"
+
+[script]
+dependencies = []
+```
+
+- [ ] **Step 2: Settings**
+
+Create `src/Settings.as`:
+
+```angelscript
+[Setting category="Connection" name="Enabled"]
+bool S_Enabled = true;
+
+[Setting category="Connection" name="Capture URL"]
+string S_CaptureUrl = "http://localhost:6996/api/capture/heat";
+
+[Setting category="Connection" name="Capture token" password]
+string S_CaptureToken = "";
+
+[Setting category="Connection" name="Manual send hotkey (VirtualKey)"]
+VirtualKey S_SendKey = VirtualKey::F8;
+```
+
+- [ ] **Step 3: Main skeleton**
+
+Create `src/Main.as`:
+
+```angelscript
+void Main() {
+    print("Chugmania Capture loaded");
+}
+
+void Update(float dt) {
+    if (!S_Enabled) return;
+    CaptureUpdate(dt);
+}
+
+void OnKeyPress(bool down, VirtualKey key) {
+    if (down && key == S_SendKey) {
+        SendCurrentHeat("manual");
+    }
+}
+```
+
+- [ ] **Step 4: Verify it loads**
+
+Reload plugins in Openplanet (`Ctrl+L`). Confirm "Chugmania Capture loaded" appears in the log and the Settings panel shows the Connection section.
+
+```bash
+git add info.toml src/Settings.as src/Main.as
+git commit -m "feat: plugin scaffold + connection settings"
+```
+
+---
+
+## Task 2: Per-slot best-time tracking
+
+**Files:**
+- Create: `src/Capture.as`
+
+Use the field names **confirmed in Task 0** if they differ from below.
+
+- [ ] **Step 1: Track best finish per slot for the current map**
+
+Create `src/Capture.as`:
+
+```angelscript
+class SlotBest {
+    int slot;
+    int bestTimeMs = -1;
+}
+
+string g_currentMapUid = "";
+string g_currentMapName = "";
+string g_currentMapAuthor = "";
+int g_playerCount = 0;
+array<SlotBest@> g_bests;
+
+SlotBest@ bestForSlot(int slot) {
+    for (uint i = 0; i < g_bests.Length; i++) {
+        if (g_bests[i].slot == slot) return g_bests[i];
+    }
+    SlotBest b;
+    b.slot = slot;
+    g_bests.InsertLast(b);
+    return g_bests[g_bests.Length - 1];
+}
+
+void resetHeat() {
+    g_bests = {};
+    g_playerCount = 0;
+}
+
+void CaptureUpdate(float dt) {
+    auto app = cast<CTrackMania>(GetApp());
+    auto pg = cast<CSmArenaClient>(app.CurrentPlayground);
+    if (pg is null) { return; }
+
+    auto map = app.RootMap;
+    if (map !is null) {
+        g_currentMapUid = map.MapInfo.MapUid;
+        g_currentMapName = map.MapInfo.Name;
+        g_currentMapAuthor = map.MapInfo.AuthorNickName;
+    }
+
+    g_playerCount = pg.Players.Length;
+    for (uint i = 0; i < pg.Players.Length; i++) {
+        auto player = cast<CSmPlayer>(pg.Players[i]);
+        if (player is null) continue;
+        auto sp = player.ScriptPlayer;
+        if (sp is null) continue;
+
+        int finish = finishTimeOf(sp);
+        if (finish > 0) {
+            auto b = bestForSlot(int(i) + 1);
+            if (b.bestTimeMs < 0 || finish < b.bestTimeMs) {
+                b.bestTimeMs = finish;
+            }
+        }
+    }
+}
+
+// Returns the finish time in ms if the player has crossed the finish, else -1.
+// Confirm the exact finish signal during Task 0 (waypoint count == checkpoint
+// total, or an isEndRace-style flag). The waypoint-array form is below.
+int finishTimeOf(CSmScriptPlayer@ sp) {
+    uint n = sp.RaceWaypointTimes.Length;
+    if (n == 0) return -1;
+    // Heuristic: treat the last waypoint as the finish only when the run is
+    // complete; refine with the flag confirmed in Task 0.
+    return int(sp.RaceWaypointTimes[n - 1]);
+}
+```
+
+- [ ] **Step 2: Reload + sanity print**
+
+Temporarily add `print("slot " + b.slot + " best " + b.bestTimeMs)` after a new best is recorded; race splitscreen and confirm best-times update and only improve. Remove the print.
+
+```bash
+git add src/Capture.as
+git commit -m "feat: track best finish time per slot per map visit"
+```
+
+---
+
+## Task 3: Heat-boundary detection + manual send
+
+**Files:**
+- Modify: `src/Capture.as`
+
+- [ ] **Step 1: Detect map change and auto-send the previous heat**
+
+Add to `src/Capture.as`:
+
+```angelscript
+string g_lastSentMapUid = "";
+string g_activeMapUid = "";
+
+void onMapMaybeChanged() {
+    auto app = cast<CTrackMania>(GetApp());
+    auto map = app.RootMap;
+    string uid = map !is null ? map.MapInfo.MapUid : "";
+
+    if (uid != g_activeMapUid) {
+        // We left the previous map — flush its heat if it had any finishes.
+        if (g_activeMapUid != "" && hasAnyFinish()) {
+            SendCurrentHeat("mapEnd");
+        }
+        g_activeMapUid = uid;
+        resetHeat();
+    }
+}
+
+bool hasAnyFinish() {
+    for (uint i = 0; i < g_bests.Length; i++) {
+        if (g_bests[i].bestTimeMs > 0) return true;
+    }
+    return false;
+}
+```
+
+Call `onMapMaybeChanged()` at the top of `CaptureUpdate(dt)` (before reading players).
+
+- [ ] **Step 2: Generate a stable heatId per heat**
+
+Add a heat identifier set when a map becomes active, so retries reuse it:
+
+```angelscript
+string g_heatId = "";
+
+void newHeatId() {
+    g_heatId = "" + Time::Stamp + "-" + Math::Rand(1000, 9999);
+}
+```
+
+Call `newHeatId()` inside `onMapMaybeChanged()` right after `resetHeat()`.
+
+- [ ] **Step 3: Reload + verify the boundary**
+
+Race a map in splitscreen, finish both, then change map. Confirm (via a temporary log line in `SendCurrentHeat`, built in Task 4) that exactly one heat fires on map change, and the manual hotkey fires on demand.
+
+```bash
+git add src/Capture.as
+git commit -m "feat: heat-boundary detection + stable heatId + manual flush"
+```
+
+---
+
+## Task 4: Build payload + POST with retry
+
+**Files:**
+- Create: `src/Net.as`
+- Modify: `src/Capture.as`
+
+- [ ] **Step 1: HTTP POST with retry**
+
+Create `src/Net.as`:
+
+```angelscript
+void PostHeat(const string &in jsonBody) {
+    startnew(function(ref@ r) {
+        string body = cast<StringRef>(r).value;
+        for (int attempt = 0; attempt < 3; attempt++) {
+            auto req = Net::HttpPost(S_CaptureUrl, body, "application/json");
+            req.Headers["Authorization"] = "Bearer " + S_CaptureToken;
+            while (!req.Finished()) { yield(); }
+            int code = req.ResponseCode();
+            if (code == 200) {
+                print("Capture sent: " + req.String());
+                return;
+            }
+            print("Capture POST failed (" + code + "), attempt " + (attempt + 1));
+            sleep(1000);
+        }
+    }, StringRef(jsonBody));
+}
+
+class StringRef { string value; StringRef(const string &in v) { value = v; } }
+```
+
+> **Verify during implementation:** the exact way to set request headers (`req.Headers[...]` vs building a `Net::HttpRequest` manually and calling `Start()`) per the installed Openplanet version. If `Net::HttpPost` doesn't expose settable headers pre-send, construct a `Net::HttpRequest`, set `Method='POST'`, `Body`, `Headers`, then `Start()`.
+
+- [ ] **Step 2: Assemble + send the heat JSON**
+
+Add to `src/Capture.as`:
+
+```angelscript
+void SendCurrentHeat(const string &in reason) {
+    if (g_currentMapUid == "" || !hasAnyFinish()) return;
+    if (g_heatId == "") newHeatId();
+
+    Json::Value@ payload = Json::Object();
+    payload["contractVersion"] = 1;
+    payload["heatId"] = g_heatId;
+    payload["mapUid"] = g_currentMapUid;
+    payload["mapName"] = g_currentMapName;
+    payload["mapAuthor"] = g_currentMapAuthor;
+    payload["playerCount"] = g_playerCount;
+
+    Json::Value@ results = Json::Array();
+    for (uint i = 0; i < g_bests.Length; i++) {
+        if (g_bests[i].bestTimeMs <= 0) continue;
+        Json::Value@ r = Json::Object();
+        r["slot"] = g_bests[i].slot;
+        r["bestTimeMs"] = g_bests[i].bestTimeMs;
+        results.Add(r);
+    }
+    payload["results"] = results;
+
+    PostHeat(Json::Write(payload));
+    print("Heat sent (" + reason + "): " + g_heatId);
+}
+```
+
+- [ ] **Step 3: Reload + verify end-to-end against a running backend**
+
+With the Chugmania backend running (active session set, `CAPTURE_TOKEN` configured), race splitscreen → change map → confirm a faded row pair appears in Chugmania. Then test the `F8` manual send.
+
+```bash
+git add src/Net.as src/Capture.as
+git commit -m "feat: assemble heat payload + POST to Chugmania with retry"
+```
+
+---
+
+## Task 5: Manual test protocol + packaging
+
+**Files:**
+- Create: `README.md`
+
+- [ ] **Step 1: Run the manual test matrix**
+
+Verify and tick each:
+- Solo (1 player): one finish → one-slot heat → one faded row in Chugmania.
+- 1v1 splitscreen: two finishes → two-slot heat → linked faded rows; faster slot wins after assignment.
+- Best-of-retries: multiple finishes per slot → only the fastest is sent.
+- Map change auto-flush: exactly one heat per map visit.
+- Backend down: POST retries 3× then logs failure; bringing the backend up and pressing `F8` re-sends with the same `heatId` (idempotent — no duplicate row).
+- No active session in Chugmania: POST returns `{stored:false}`; nothing appears (correct).
+
+- [ ] **Step 2: README**
+
+Create `README.md`: install path (`OpenplanetNext/Plugins/`), the four settings, the Developer-mode requirement (or signing), and a link to the Chugmania contract doc. State the supported modes (splitscreen + solo + hotseat) and that capture only happens while a Chugmania session is active.
+
+- [ ] **Step 3: Commit + tag**
+
+```bash
+git add README.md
+git commit -m "docs: install + test protocol; v0.1.0"
+git tag v0.1.0
+```
+
+---
+
+## Appendix A: Replay-file watcher fallback
+
+Use ONLY if Task 0 shows splitscreen slots are not enumerable.
+
+- Run the existing **Autosave Ghosts** Openplanet plugin to force a `.Replay.gbx` per finished run into
+  `Documents/Trackmania/Replays/AutosavedGhosts/<Map>/<Date>-<Map>-<Nick>-<RaceTime>.Replay.gbx`.
+- A small Node watcher (its own repo, using `chokidar`) parses new files with **GBX.NET** (`Gbx.LZO = new Lzo()`, `CGameCtnGhost.RaceTime` + nickname) — or, simpler, parses the **filename** which already embeds nickname + race time.
+- It then POSTs the same `/api/capture/heat` payload. Note: splitscreen per-slot ghost saving is unverified — confirm during the fallback's own spike. This path is non-real-time (fires after the run is written).

--- a/docs/superpowers/specs/2026-06-08-trackmania-autocapture-design.md
+++ b/docs/superpowers/specs/2026-06-08-trackmania-autocapture-design.md
@@ -4,6 +4,8 @@
 **Status:** Approved design, pending implementation plan
 **Supersedes:** `CHUGMANIA_AUTOCAPTURE_PLAN.md` (the original brief assumed a dedicated-server/XML-RPC architecture; this document replaces that architecture wholesale — see §10).
 
+**Delivery:** Two repos. (a) The **Openplanet plugin** is its own, separately-owned repo (different language/runtime/distribution). (b) The **Chugmania backend + frontend** changes land as a **PR to the upstream Chugmania repo** (which the author of this work does not own). The only coupling is the versioned `POST /api/capture/heat` JSON contract (§7), documented in the Chugmania repo. The fixture-based ingest tests (T2) let the Chugmania PR be reviewed and verified without the plugin present.
+
 ---
 
 ## 1. Goal
@@ -55,7 +57,7 @@ as before.
 - Dedicated-server / XML-RPC / `@evotm/gbxclient` route.
 - PS5 / console capture.
 - Any new UI design system — reuse existing components only.
-- Persisting unassigned captures across restarts (pending lives in memory for v1).
+- Tournament-bracket auto-binding — assignment stays manual via the "Ubekrefta runder" table.
 
 ---
 
@@ -76,22 +78,25 @@ Four independently testable units:
 [Chugmania backend]  CaptureManager
      │  • if no active session → discard (log, 200)        ← per user decision
      │  • auto-create tracks row if mapUid unseen
-     │  • create in-memory pending capture (dedupe by heatId)
-     │  • emit 'capture_pending' to admin/mod clients
+     │  • persist unconfirmed_laps row(s) (one per slot, linked by heatId; dedupe by heatId)
+     │  • broadcast 'all_unconfirmed_laps' (role-aware: admin/mod)
      ▼
-[Chugmania frontend]  Live-capture popup
-     │  solo → 1 player dropdown | 1v1 → 2 dropdowns + Swap; time & map prefilled
-     │  emit 'commit_capture' { pendingId, assignments:[{slot,userId}] }
+[Chugmania frontend]  "Ubekrefta runder" faded table at top of the active session
+     │  faded row = time + map, no name/rank; click a row →
+     │  popup (solo → 1 dropdown | 1v1 → 2 dropdowns + Swap; time & map read-only)
+     │  emit 'confirm_capture' { heatId, assignments:[{slot,userId}] }
      ▼
-[Chugmania backend]  commit
-     • write time_entries (source='auto', duration=bestTimeMs) per assigned player on active session
+[Chugmania backend]  confirm
+     • write time_entries (source='auto', duration=bestTimeMs) per assigned player on the session
      • for 1v1: write completed matches row (user1,user2,track,session,winner=faster)
-     • RatingManager.recalculate(); broadcast all_time_entries / all_matches / all_rankings
+     • delete the heat's unconfirmed_laps rows
+     • RatingManager.recalculate(); broadcast all_time_entries / all_matches / all_rankings / all_unconfirmed_laps
 ```
 
 ### 4.1 Where the listener lives
 The Openplanet plugin **is** the external listener; it replaces the separate Node sibling service from the
-original brief. The backend only gains an HTTP ingest route — no second process to run.
+original brief. The backend only gains an HTTP ingest route — no second process to run. The plugin ships as
+its own repo; the backend/frontend changes ship as a PR to the Chugmania repo (see header **Delivery**).
 
 ---
 
@@ -117,25 +122,34 @@ original brief. The backend only gains an HTTP ingest route — no second proces
 - **Validation:** shape-check payload (mirror the `isXRequest` guard pattern); reject malformed.
 - **No active session → discard:** log a debug line and return `200` so the plugin does not retry. (User
   decision: captures outside an active session are ignored.)
-- **Dedupe:** ignore a heat whose `heatId` is already pending or already committed.
+- **Dedupe:** ignore a heat whose `heatId` already exists in `unconfirmed_laps` or has been confirmed.
 - **Track auto-create:** if `mapUid` not in `tracks`, insert a TM2020 map row (`mapUid`, `name`, `author`).
-- **Pending model:** in-memory map of `pendingId → { heatId, sessionId, trackId, playerCount, results }`.
-  Emit `capture_pending` to admin/mod sockets.
-- **Commit (`commit_capture`):** validate assignments (distinct users for 1v1; users exist); write
-  `time_entries` (`source='auto'`, `duration=bestTimeMs`, `track`, `session`=active) per assignment; for
-  1v1 also insert a `matches` row (`status='completed'`, `winner` = faster slot's user); then
-  `RatingManager.recalculate()` and the three existing broadcasts. Remove the pending entry.
-- **Permissions:** committing requires `admin`/`moderator` (reuse `AuthManager.checkAuth`).
+- **Persist as unconfirmed:** insert one `unconfirmed_laps` row per slot (linked by `heatId`, carrying
+  `slot`, `durationMs`, `playerCount`, `session`, `track`); broadcast `all_unconfirmed_laps`. These survive
+  refreshes and restarts — they are the backing store for the "Ubekrefta runder" table.
+- **Confirm (`confirm_capture`):** validate assignments (distinct users for 1v1; users exist); write
+  `time_entries` (`source='auto'`, `duration=durationMs`, `track`, `session`) per assignment; for 1v1 also
+  insert a `matches` row (`status='completed'`, `winner` = faster slot's user); delete the heat's
+  `unconfirmed_laps` rows; then `RatingManager.recalculate()` and broadcast
+  `all_time_entries`/`all_matches`/`all_rankings`/`all_unconfirmed_laps`.
+- **Discard (`discard_capture`):** delete a heat's `unconfirmed_laps` rows without writing (for junk/aborted
+  runs); broadcast `all_unconfirmed_laps`.
+- **Permissions:** confirming/discarding requires `admin`/`moderator` (reuse `AuthManager.checkAuth`).
 
 ### 5.3 Live-capture UI (frontend)
 - **Active-session control:** lets an admin mark one session "live for capture" (defaults to today's/nearest
   session). Stored as capture state on the backend; surfaced via `capture_state`.
-- **Pending popup:** on `capture_pending`, show the template by `playerCount`:
-  - **Solo:** one `NativeSelect` player dropdown; prefilled time + map (read-only).
-  - **1v1:** two `NativeSelect` dropdowns (one per slot) showing each slot's time + map; a **Swap** button to
-    exchange which slot maps to which player; confirm.
+- **"Ubekrefta runder" table:** rendered at the **top of the active session view** (admin/mod only), styled
+  like the existing leaderboard rows but **faded, with no name and no rank** — each faded row shows the
+  captured **time + map**. Backed by `all_unconfirmed_laps`. Rows from the same `heatId` are visually linked.
+- **Click-to-confirm popup:** clicking a faded row opens a `Dialog` scoped to that heat:
+  - **Solo (`playerCount = 1`):** one `NativeSelect` player dropdown; time + map shown read-only.
+  - **1v1 (`playerCount = 2`):** two `NativeSelect` dropdowns (one per slot) with each slot's time + map; a
+    **Swap** button to exchange which slot maps to which player; confirm.
+  - Confirm emits `confirm_capture`; a discard action emits `discard_capture`.
 - Built from existing components (`NativeSelect`, `Dialog`, `sonner` toasts). No new design language.
-- After commit, the existing leaderboard/match views update through the normal broadcast path.
+- After confirm, the faded row disappears and the existing leaderboard/match views update through the normal
+  broadcast path — auto and manual entries sit on the same leaderboard.
 
 ### 5.4 Parallelism guarantee
 Auto-capture adds only: one Express route, one manager, new socket events, two nullable-friendly schema
@@ -159,9 +173,19 @@ Minimal, "add alongside" — existing Turbo data is preserved.
 ### `time_entries`
 - Add `source TEXT NOT NULL DEFAULT 'manual'` with type `'manual' | 'auto'`.
 
+### `unconfirmed_laps` (new table — backs the "Ubekrefta runder" list)
+- `id` (pk), standard `createdAt`/`updatedAt`/`deletedAt` metadata.
+- `session` (FK `sessions`, the active session), `track` (FK `tracks`, the TM2020 map).
+- `heatId TEXT NOT NULL` — groups the slot rows belonging to one race; also the idempotency key.
+- `slot INTEGER NOT NULL` — 1 or 2.
+- `durationMs INTEGER NOT NULL` — the captured best time for that slot.
+- `playerCount INTEGER NOT NULL` — 1 (solo) or 2 (1v1); drives the popup template.
+- Rows are created on ingest and deleted on confirm/discard. They are never shown on the leaderboard (only
+  in the faded table) and never feed ratings until confirmed into `time_entries`.
+
 ### Process
 - Run `npm run db:gen` to generate the Drizzle migration after editing `schema.ts`.
-- Add the new columns to `AdminManager` `TABLE_MAP` / `EXCLUDED_COL_EXPORT` per `AGENTS.md` so CSV
+- Add the new table/columns to `AdminManager` `TABLE_MAP` / `EXCLUDED_COL_EXPORT` per `AGENTS.md` so CSV
   import/export stays complete.
 
 ### No change to `users`
@@ -171,11 +195,13 @@ Slots are assigned to players manually each heat, so no TM-login/AccountId field
 
 ## 7. Socket.IO & HTTP contract additions
 
-- **HTTP** `POST /api/capture/heat` (token-auth) — body in §4.
-- **Server→client** `capture_state` (active session + config), `capture_pending` (a pending capture to
-  assign). Emitted role-aware to admin/mod only.
-- **Client→server** `set_active_session` (mark/clear the live session), `commit_capture`
-  (`{ pendingId, assignments }`), `discard_pending` (`{ pendingId }`).
+- **HTTP** `POST /api/capture/heat` (token-auth, **versioned contract**) — body in §4. The JSON schema is
+  documented in the Chugmania repo and consumed by the separate plugin repo; bump a `contractVersion` field
+  when it changes so plugin and backend can evolve independently.
+- **Server→client** `capture_state` (active session + config), `all_unconfirmed_laps` (the faded-table
+  list for the active session). Emitted role-aware to admin/mod only.
+- **Client→server** `set_active_session` (mark/clear the live session), `confirm_capture`
+  (`{ heatId, assignments:[{slot,userId}] }`), `discard_capture` (`{ heatId }`).
 - All follow the existing `setup(s, event, handler)` wiring and `Result<T>`/`SuccessResponse|ErrorResponse`
   conventions.
 
@@ -184,14 +210,14 @@ Slots are assigned to players manually each heat, so no TM-login/AccountId field
 ## 8. Edge handling
 
 - **No active session:** discard (log, 200). No retry, no queue.
-- **Duplicate heat:** deduped by `heatId` (pending or committed).
+- **Duplicate heat:** deduped by `heatId` (unconfirmed or already confirmed).
 - **Plugin/HTTP failure:** plugin retries with the same `heatId`; backend is idempotent.
-- **Backend restart mid-session:** in-memory pending is lost (acceptable for v1 — a heat is assigned within
-  seconds); active-session selection is re-set by the admin. Persisting pending is flagged as later hardening.
-- **Wrong template / wrong map / wrong player:** correctable after the fact via the existing time-entry and
-  match edit flows.
-- **Unassigned pending:** stays until committed or explicitly discarded; never auto-writes.
-- **>2 players:** out of scope for v1 templates; backend logs and discards (or holds without a template).
+- **Backend restart mid-session:** unconfirmed laps are **persisted in the DB**, so the "Ubekrefta runder"
+  table survives restarts and page refreshes; only the active-session pointer is re-set by the admin.
+- **Wrong map / wrong player:** correctable before confirm (pick correctly / discard) and after confirm via
+  the existing time-entry and match edit flows.
+- **Unassigned captures:** remain as faded rows until confirmed or explicitly discarded; never auto-write.
+- **>2 players:** out of scope for v1 templates; backend logs and discards.
 
 ---
 
@@ -223,18 +249,21 @@ insight from the brief survives; only the capture transport changed.
   name/index, and `RaceWaypointTimes` during 2-player splitscreen and hotseat. Record real payloads as
   golden fixtures. Directly mitigates the "verify against the running game / docs drift" risk.
 - **T1 — Backend logic unit tests** (`*.spec.ts` via `tsx`): payload validation; best-time selection;
-  solo-vs-1v1 routing; slot→player binding + swap; winner derivation; idempotency/dedupe by `heatId`;
-  no-active-session discard; track auto-create.
+  solo-vs-1v1 routing; `unconfirmed_laps` creation; slot→player binding + swap; winner derivation;
+  idempotency/dedupe by `heatId`; no-active-session discard; track auto-create; confirm deletes the heat's
+  unconfirmed rows.
 - **T2 — Ingest integration tests:** a `mock-plugin` script POSTs recorded/synthetic fixtures to
-  `/api/capture/heat`; assert DB rows, `matches` rows, and emitted socket events — full loop **without the
-  game running**.
+  `/api/capture/heat`; assert `unconfirmed_laps` rows + `all_unconfirmed_laps` broadcast, then drive
+  `confirm_capture` and assert `time_entries`/`matches` rows and broadcasts — full loop **without the game
+  running**. This is what lets the Chugmania PR be verified standalone.
 - **T3 — Plugin manual tests** (gaming PC): finish detection; best-of-retries; map-end trigger;
   HTTP retry while backend is down then recovers.
-- **T4 — Full manual E2E protocol** (real setup, checklist): solo run → leaderboard row; 1v1 → two rows +
-  match winner + swap correctness; capture while no session active → ignored; backend restart recovery;
-  manual entry still works alongside.
-- **T5 — Reliability/edge:** duplicate finishes; plugin reconnect; wrong-template correction via edit flow;
-  parallel manual + auto entries on the same session/leaderboard.
+- **T4 — Full manual E2E protocol** (real setup, checklist): solo run → faded "Ubekrefta runder" row →
+  click → assign → leaderboard row; 1v1 → two linked faded rows → confirm with swap → two entries + match
+  winner; capture while no session active → ignored; backend restart → faded rows persist; manual entry
+  still works alongside.
+- **T5 — Reliability/edge:** duplicate finishes; plugin reconnect; discard junk capture; post-confirm
+  correction via edit flow; parallel manual + auto entries on the same session/leaderboard.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-08-trackmania-autocapture-design.md
+++ b/docs/superpowers/specs/2026-06-08-trackmania-autocapture-design.md
@@ -1,0 +1,245 @@
+# Chugmania — Trackmania 2020 Auto-Capture (v1 Design)
+
+**Date:** 2026-06-08
+**Status:** Approved design, pending implementation plan
+**Supersedes:** `CHUGMANIA_AUTOCAPTURE_PLAN.md` (the original brief assumed a dedicated-server/XML-RPC architecture; this document replaces that architecture wholesale — see §10).
+
+---
+
+## 1. Goal
+
+Capture finish times from in-person Trackmania 2020 sessions automatically, so a player crossing the
+finish line produces a correct time-entry row in Chugmania with no manual time/map typing, visible in the
+existing frontend — **running in parallel with, and without disturbing, the existing manual workflow.**
+
+**Definition of done (v1):** during a live session, a finished splitscreen or solo run on the gaming PC
+produces, after a one-tap player assignment, a correct `time_entries` row (and a `matches` row for 1v1)
+attached to the active session, visible on the existing leaderboard. Manual entry continues to work exactly
+as before.
+
+---
+
+## 2. Key facts that shape this design (researched, cited)
+
+- **PS5 cannot capture.** Consoles block mods, can't run or join dedicated servers, and have no XML-RPC.
+  The racing rig must be a **PC**. ([doc.trackmania.com](https://doc.trackmania.com/club/activities/room/))
+- **TM2020 has local splitscreen + hotseat** (confirmed in-game on the free Starter tier). Splitscreen is a
+  *local client session* — **no server, no XML-RPC**. Capture must therefore be **client-side**.
+- **Openplanet runs during offline local splitscreen** and a plugin can read each player's finish/checkpoint
+  times via `CSmArenaClient.Players` → `CSmScriptPlayer.RaceWaypointTimes`, and POST JSON out via
+  `Net::HttpPost`. ([CSmArenaClient](https://next.openplanet.dev/ShootMania/CSmArenaClient),
+  [Net API](https://openplanet.dev/docs/api/Net/HttpPost),
+  [PlayerState Info plugin](https://openplanet.dev/plugin/playerstate))
+- **Splitscreen players are local controller slots** (Player 1 / Player 2) under one login, *not* separate
+  accounts. The game never knows which human took which seat — so seat→player binding is a manual step in
+  Chugmania.
+- **Cost:** ~$20/yr Club Access on the gaming PC for Openplanet Developer mode (to run our own unsigned
+  plugin), or get the plugin signed. ([Openplanet signature modes](https://openplanet.dev/docs/tutorials/signature-modes))
+
+---
+
+## 3. Scope
+
+**In:**
+- Openplanet plugin capturing best finish time per slot per map visit (solo and 1v1 splitscreen).
+- Backend ingest endpoint + capture manager.
+- Between-maps assignment popup with two templates (solo / 1v1), manual player selection, swap for 1v1.
+- Auto-creation of a TM2020 map (`tracks` row) on first sighting.
+- Writing `time_entries` (+ a completed `matches` row for 1v1) on the **active session**.
+- Reuse of existing reactive Socket.IO broadcasts, leaderboard, and edit flows.
+
+**Out (deferred / non-goals):**
+- Tournament-bracket auto-binding (explicitly deferred — assignment is manual for v1).
+- Checkpoints/splits, multi-round/match structures, ModeScript game modes.
+- Drink/`amount_l` tracking — the chug is performed before the lap, so it is baked into the race time.
+- Dedicated-server / XML-RPC / `@evotm/gbxclient` route.
+- PS5 / console capture.
+- Any new UI design system — reuse existing components only.
+- Persisting unassigned captures across restarts (pending lives in memory for v1).
+
+---
+
+## 4. Architecture
+
+Four independently testable units:
+
+1. **Openplanet plugin** (new; gaming PC; AngelScript) — reads game state, POSTs heat results.
+2. **Capture ingest + manager** (new; existing Express backend) — validates, holds pending, commits writes.
+3. **Live-capture UI** (new; existing React frontend) — active-session control, pending list, assignment popup.
+4. **Existing data layer** (unchanged) — `time_entries`, `matches`, ratings, leaderboard, Socket.IO broadcasts.
+
+```
+[Gaming PC]  Trackmania 2020 + Openplanet plugin
+     │  best finish time per slot for the current map visit
+     │  HTTP POST /api/capture/heat  { token, heatId, mapUid, mapName, playerCount, results:[{slot,bestTimeMs}], serverTime }
+     ▼
+[Chugmania backend]  CaptureManager
+     │  • if no active session → discard (log, 200)        ← per user decision
+     │  • auto-create tracks row if mapUid unseen
+     │  • create in-memory pending capture (dedupe by heatId)
+     │  • emit 'capture_pending' to admin/mod clients
+     ▼
+[Chugmania frontend]  Live-capture popup
+     │  solo → 1 player dropdown | 1v1 → 2 dropdowns + Swap; time & map prefilled
+     │  emit 'commit_capture' { pendingId, assignments:[{slot,userId}] }
+     ▼
+[Chugmania backend]  commit
+     • write time_entries (source='auto', duration=bestTimeMs) per assigned player on active session
+     • for 1v1: write completed matches row (user1,user2,track,session,winner=faster)
+     • RatingManager.recalculate(); broadcast all_time_entries / all_matches / all_rankings
+```
+
+### 4.1 Where the listener lives
+The Openplanet plugin **is** the external listener; it replaces the separate Node sibling service from the
+original brief. The backend only gains an HTTP ingest route — no second process to run.
+
+---
+
+## 5. Components in detail
+
+### 5.1 Openplanet plugin (gaming PC)
+- **Mode detection:** read the count of active local player slots in the current playground →
+  `playerCount` (1 = solo, 2 = 1v1). Tag every heat with it.
+- **Timing:** for each `CSmPlayer` in `CSmArenaClient.Players`, read `ScriptPlayer.RaceWaypointTimes`;
+  the final waypoint is the finish time. Track the **best (min) finish time per slot for the current map
+  visit**, not every retry.
+- **Heat boundary:** emit on map end (player leaves map / map changes). Provide a manual "send now" key
+  binding as a fallback in case map-end detection proves unreliable.
+- **Map identity:** read `MapUid` and name from the loaded map.
+- **Transport:** `Net::HttpPost(captureUrl, json, "application/json")` with a shared `token` and a
+  client-generated `heatId` (stable across retries). Retry on failure; `heatId` makes the backend idempotent.
+- **Config:** capture URL (localhost or LAN IP of the Chugmania backend) and token, stored in plugin settings.
+
+### 5.2 Capture ingest + manager (backend)
+- **Route:** `POST /api/capture/heat` registered in `server.ts` alongside the existing
+  `/api/sessions/calendar.ics` Express route; delegates to a new `CaptureManager`.
+- **Auth:** shared-secret token (`CAPTURE_TOKEN` env) compared in constant-ish time; reject otherwise.
+- **Validation:** shape-check payload (mirror the `isXRequest` guard pattern); reject malformed.
+- **No active session → discard:** log a debug line and return `200` so the plugin does not retry. (User
+  decision: captures outside an active session are ignored.)
+- **Dedupe:** ignore a heat whose `heatId` is already pending or already committed.
+- **Track auto-create:** if `mapUid` not in `tracks`, insert a TM2020 map row (`mapUid`, `name`, `author`).
+- **Pending model:** in-memory map of `pendingId → { heatId, sessionId, trackId, playerCount, results }`.
+  Emit `capture_pending` to admin/mod sockets.
+- **Commit (`commit_capture`):** validate assignments (distinct users for 1v1; users exist); write
+  `time_entries` (`source='auto'`, `duration=bestTimeMs`, `track`, `session`=active) per assignment; for
+  1v1 also insert a `matches` row (`status='completed'`, `winner` = faster slot's user); then
+  `RatingManager.recalculate()` and the three existing broadcasts. Remove the pending entry.
+- **Permissions:** committing requires `admin`/`moderator` (reuse `AuthManager.checkAuth`).
+
+### 5.3 Live-capture UI (frontend)
+- **Active-session control:** lets an admin mark one session "live for capture" (defaults to today's/nearest
+  session). Stored as capture state on the backend; surfaced via `capture_state`.
+- **Pending popup:** on `capture_pending`, show the template by `playerCount`:
+  - **Solo:** one `NativeSelect` player dropdown; prefilled time + map (read-only).
+  - **1v1:** two `NativeSelect` dropdowns (one per slot) showing each slot's time + map; a **Swap** button to
+    exchange which slot maps to which player; confirm.
+- Built from existing components (`NativeSelect`, `Dialog`, `sonner` toasts). No new design language.
+- After commit, the existing leaderboard/match views update through the normal broadcast path.
+
+### 5.4 Parallelism guarantee
+Auto-capture adds only: one Express route, one manager, new socket events, two nullable-friendly schema
+additions, and one UI panel. It changes **no** existing manager, endpoint, or component. Manual time/match
+entry, CSV import/export, sessions, and tournaments behave exactly as today. `source` distinguishes the
+origin of a row for audit; both kinds coexist on the same leaderboard.
+
+---
+
+## 6. Data model changes
+
+Minimal, "add alongside" — existing Turbo data is preserved.
+
+### `tracks`
+- Add `mapUid TEXT UNIQUE` (nullable) — TM2020 MapUid.
+- Add `name TEXT` (nullable) — TM2020 map name.
+- Add `author TEXT` (nullable) — TM2020 map author.
+- Relax `number`, `level`, `type` to **nullable** so a TM2020 map can exist without Turbo attributes.
+  Existing Turbo rows keep their values.
+
+### `time_entries`
+- Add `source TEXT NOT NULL DEFAULT 'manual'` with type `'manual' | 'auto'`.
+
+### Process
+- Run `npm run db:gen` to generate the Drizzle migration after editing `schema.ts`.
+- Add the new columns to `AdminManager` `TABLE_MAP` / `EXCLUDED_COL_EXPORT` per `AGENTS.md` so CSV
+  import/export stays complete.
+
+### No change to `users`
+Slots are assigned to players manually each heat, so no TM-login/AccountId field is required.
+
+---
+
+## 7. Socket.IO & HTTP contract additions
+
+- **HTTP** `POST /api/capture/heat` (token-auth) — body in §4.
+- **Server→client** `capture_state` (active session + config), `capture_pending` (a pending capture to
+  assign). Emitted role-aware to admin/mod only.
+- **Client→server** `set_active_session` (mark/clear the live session), `commit_capture`
+  (`{ pendingId, assignments }`), `discard_pending` (`{ pendingId }`).
+- All follow the existing `setup(s, event, handler)` wiring and `Result<T>`/`SuccessResponse|ErrorResponse`
+  conventions.
+
+---
+
+## 8. Edge handling
+
+- **No active session:** discard (log, 200). No retry, no queue.
+- **Duplicate heat:** deduped by `heatId` (pending or committed).
+- **Plugin/HTTP failure:** plugin retries with the same `heatId`; backend is idempotent.
+- **Backend restart mid-session:** in-memory pending is lost (acceptable for v1 — a heat is assigned within
+  seconds); active-session selection is re-set by the admin. Persisting pending is flagged as later hardening.
+- **Wrong template / wrong map / wrong player:** correctable after the fact via the existing time-entry and
+  match edit flows.
+- **Unassigned pending:** stays until committed or explicitly discarded; never auto-writes.
+- **>2 players:** out of scope for v1 templates; backend logs and discards (or holds without a template).
+
+---
+
+## 9. Human prerequisites (cannot be done by the implementer)
+
+1. **Feasibility spike (T0 — the one real unknown):** install Openplanet on the gaming PC, run a 2-player
+   splitscreen Time Attack, and confirm a probe plugin sees **both** slots and their `RaceWaypointTimes`.
+   This gates the plugin build. If it fails, fall back to a replay-file watcher (`Autosave Ghosts` plugin +
+   GBX.NET parsing), accepting non-real-time capture.
+2. **Club Access (~$20/yr)** on the gaming PC for Openplanet Developer mode (or sign the plugin).
+3. Record real heat payloads during T0 to use as golden fixtures for automated tests.
+
+---
+
+## 10. Why this replaces the original brief
+
+The original brief specified a dedicated server + XML-RPC + `@evotm/gbxclient` listener, on the assumption
+that players connect as clients to a server. Research showed (a) PS5 can't participate at all, and (b)
+TM2020's local splitscreen — the most couch-friendly setup, and what the group actually wants — has no
+server and no XML-RPC. Client-side Openplanet capture is simpler (one PC, no server to stand up, free-tier
+play), fits couch 1v1 better, and removes the entire LAN-server prerequisite chain. The seat→player binding
+insight from the brief survives; only the capture transport changed.
+
+---
+
+## 11. Test execution plan
+
+- **T0 — Feasibility spike** (manual, gaming PC). Probe plugin prints `Players.Length`, each slot's
+  name/index, and `RaceWaypointTimes` during 2-player splitscreen and hotseat. Record real payloads as
+  golden fixtures. Directly mitigates the "verify against the running game / docs drift" risk.
+- **T1 — Backend logic unit tests** (`*.spec.ts` via `tsx`): payload validation; best-time selection;
+  solo-vs-1v1 routing; slot→player binding + swap; winner derivation; idempotency/dedupe by `heatId`;
+  no-active-session discard; track auto-create.
+- **T2 — Ingest integration tests:** a `mock-plugin` script POSTs recorded/synthetic fixtures to
+  `/api/capture/heat`; assert DB rows, `matches` rows, and emitted socket events — full loop **without the
+  game running**.
+- **T3 — Plugin manual tests** (gaming PC): finish detection; best-of-retries; map-end trigger;
+  HTTP retry while backend is down then recovers.
+- **T4 — Full manual E2E protocol** (real setup, checklist): solo run → leaderboard row; 1v1 → two rows +
+  match winner + swap correctness; capture while no session active → ignored; backend restart recovery;
+  manual entry still works alongside.
+- **T5 — Reliability/edge:** duplicate finishes; plugin reconnect; wrong-template correction via edit flow;
+  parallel manual + auto entries on the same session/leaderboard.
+
+---
+
+## 12. Open items to confirm during implementation (Phase 1 findings)
+
+- Exact current mechanism for how a manual time entry selects its session (to mirror for "active session").
+- Precise `matches` write for a 1v1 result (single `duration` column vs the two per-player `time_entries`).
+- Whether map-end is reliably detectable in the plugin, or the manual "send now" trigger should be primary.

--- a/drizzle/0010_easy_sphinx.sql
+++ b/drizzle/0010_easy_sphinx.sql
@@ -27,7 +27,7 @@ CREATE TABLE `__new_tracks` (
 	`author` text
 );
 --> statement-breakpoint
-INSERT INTO `__new_tracks`("id", "updated_at", "created_at", "deleted_at", "number", "level", "type", "map_uid", "name", "author") SELECT "id", "updated_at", "created_at", "deleted_at", "number", "level", "type", "map_uid", "name", "author" FROM `tracks`;--> statement-breakpoint
+INSERT INTO `__new_tracks`("id", "updated_at", "created_at", "deleted_at", "number", "level", "type") SELECT "id", "updated_at", "created_at", "deleted_at", "number", "level", "type" FROM `tracks`;--> statement-breakpoint
 DROP TABLE `tracks`;--> statement-breakpoint
 ALTER TABLE `__new_tracks` RENAME TO `tracks`;--> statement-breakpoint
 PRAGMA foreign_keys=ON;--> statement-breakpoint

--- a/drizzle/0010_easy_sphinx.sql
+++ b/drizzle/0010_easy_sphinx.sql
@@ -32,4 +32,4 @@ DROP TABLE `tracks`;--> statement-breakpoint
 ALTER TABLE `__new_tracks` RENAME TO `tracks`;--> statement-breakpoint
 PRAGMA foreign_keys=ON;--> statement-breakpoint
 CREATE UNIQUE INDEX `tracks_map_uid_unique` ON `tracks` (`map_uid`);--> statement-breakpoint
-ALTER TABLE `time_entries` ADD `source` text NOT NULL;
+ALTER TABLE `time_entries` ADD `source` text DEFAULT 'manual' NOT NULL;

--- a/drizzle/0010_fine_dagger.sql
+++ b/drizzle/0010_fine_dagger.sql
@@ -1,0 +1,35 @@
+CREATE TABLE `unconfirmed_laps` (
+	`id` text PRIMARY KEY NOT NULL,
+	`updated_at` integer,
+	`created_at` integer NOT NULL,
+	`deleted_at` integer,
+	`session` text NOT NULL,
+	`track` text NOT NULL,
+	`heat_id` text NOT NULL,
+	`slot` integer NOT NULL,
+	`duration_ms` integer NOT NULL,
+	`player_count` integer NOT NULL,
+	FOREIGN KEY (`session`) REFERENCES `sessions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`track`) REFERENCES `tracks`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_tracks` (
+	`id` text PRIMARY KEY NOT NULL,
+	`updated_at` integer,
+	`created_at` integer NOT NULL,
+	`deleted_at` integer,
+	`number` integer,
+	`level` text,
+	`type` text,
+	`map_uid` text,
+	`name` text,
+	`author` text
+);
+--> statement-breakpoint
+INSERT INTO `__new_tracks`("id", "updated_at", "created_at", "deleted_at", "number", "level", "type", "map_uid", "name", "author") SELECT "id", "updated_at", "created_at", "deleted_at", "number", "level", "type", "map_uid", "name", "author" FROM `tracks`;--> statement-breakpoint
+DROP TABLE `tracks`;--> statement-breakpoint
+ALTER TABLE `__new_tracks` RENAME TO `tracks`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `tracks_map_uid_unique` ON `tracks` (`map_uid`);--> statement-breakpoint
+ALTER TABLE `time_entries` ADD `source` text NOT NULL;

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1219 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9e683aac-a67b-46b6-b569-861a433238a5",
+  "prevId": "a036dd3d-568f-4bb5-8c98-abedbc61325f",
+  "tables": {
+    "group_players": {
+      "name": "group_players",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user": {
+          "name": "user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_players_group_groups_id_fk": {
+          "name": "group_players_group_groups_id_fk",
+          "tableFrom": "group_players",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_players_user_users_id_fk": {
+          "name": "group_players_user_users_id_fk",
+          "tableFrom": "group_players",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "groups": {
+      "name": "groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tournament": {
+          "name": "tournament",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groups_tournament_tournaments_id_fk": {
+          "name": "groups_tournament_tournaments_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "tournaments",
+          "columnsFrom": [
+            "tournament"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matches": {
+      "name": "matches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user1": {
+          "name": "user1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user2": {
+          "name": "user2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session": {
+          "name": "session",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_user1_users_id_fk": {
+          "name": "matches_user1_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_user2_users_id_fk": {
+          "name": "matches_user2_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_track_tracks_id_fk": {
+          "name": "matches_track_tracks_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_session_sessions_id_fk": {
+          "name": "matches_session_sessions_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_winner_users_id_fk": {
+          "name": "matches_winner_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_signups": {
+      "name": "session_signups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session": {
+          "name": "session",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user": {
+          "name": "user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_signups_session_sessions_id_fk": {
+          "name": "session_signups_session_sessions_id_fk",
+          "tableFrom": "session_signups",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_signups_user_users_id_fk": {
+          "name": "session_signups_user_users_id_fk",
+          "tableFrom": "session_signups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "time_entries": {
+      "name": "time_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user": {
+          "name": "user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session": {
+          "name": "session",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_l": {
+          "name": "amount_l",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "time_entries_user_users_id_fk": {
+          "name": "time_entries_user_users_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "time_entries_track_tracks_id_fk": {
+          "name": "time_entries_track_tracks_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "time_entries_session_sessions_id_fk": {
+          "name": "time_entries_session_sessions_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tournament_matches": {
+      "name": "tournament_matches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tournament": {
+          "name": "tournament",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bracket": {
+          "name": "bracket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "match": {
+          "name": "match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_group_a": {
+          "name": "source_group_a",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_group_a_rank": {
+          "name": "source_group_a_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_group_b": {
+          "name": "source_group_b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_group_b_rank": {
+          "name": "source_group_b_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_match_a": {
+          "name": "source_match_a",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_match_a_progression": {
+          "name": "source_match_a_progression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_match_b": {
+          "name": "source_match_b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_match_b_progression": {
+          "name": "source_match_b_progression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tournament_matches_tournament_tournaments_id_fk": {
+          "name": "tournament_matches_tournament_tournaments_id_fk",
+          "tableFrom": "tournament_matches",
+          "tableTo": "tournaments",
+          "columnsFrom": [
+            "tournament"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_matches_match_matches_id_fk": {
+          "name": "tournament_matches_match_matches_id_fk",
+          "tableFrom": "tournament_matches",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_matches_track_tracks_id_fk": {
+          "name": "tournament_matches_track_tracks_id_fk",
+          "tableFrom": "tournament_matches",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_matches_source_group_a_groups_id_fk": {
+          "name": "tournament_matches_source_group_a_groups_id_fk",
+          "tableFrom": "tournament_matches",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_matches_source_group_b_groups_id_fk": {
+          "name": "tournament_matches_source_group_b_groups_id_fk",
+          "tableFrom": "tournament_matches",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "source_group_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tournaments": {
+      "name": "tournaments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session": {
+          "name": "session",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "groups_count": {
+          "name": "groups_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "advancement_count": {
+          "name": "advancement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "elimination_type": {
+          "name": "elimination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tournaments_session_sessions_id_fk": {
+          "name": "tournaments_session_sessions_id_fk",
+          "tableFrom": "tournaments",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_uid": {
+          "name": "map_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tracks_map_uid_unique": {
+          "name": "tracks_map_uid_unique",
+          "columns": [
+            "map_uid"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "unconfirmed_laps": {
+      "name": "unconfirmed_laps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session": {
+          "name": "session",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heat_id": {
+          "name": "heat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_count": {
+          "name": "player_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "unconfirmed_laps_session_sessions_id_fk": {
+          "name": "unconfirmed_laps_session_sessions_id_fk",
+          "tableFrom": "unconfirmed_laps",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "unconfirmed_laps_track_tracks_id_fk": {
+          "name": "unconfirmed_laps_track_tracks_id_fk",
+          "tableFrom": "unconfirmed_laps",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_short_name_unique": {
+          "name": "users_short_name_unique",
+          "columns": [
+            "short_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "9e683aac-a67b-46b6-b569-861a433238a5",
+  "id": "2b41ff42-14e0-4986-9225-cbdba6859243",
   "prevId": "a036dd3d-568f-4bb5-8c98-abedbc61325f",
   "tables": {
     "group_players": {
@@ -561,7 +561,8 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "autoincrement": false
+          "autoincrement": false,
+          "default": "'manual'"
         }
       },
       "indexes": {},

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -75,8 +75,8 @@
     {
       "idx": 10,
       "version": "6",
-      "when": 1780938944108,
-      "tag": "0010_fine_dagger",
+      "when": 1780939227361,
+      "tag": "0010_easy_sphinx",
       "breakpoints": true
     }
   ]

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1767445073684,
       "tag": "0009_nappy_centennial",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1780938944108,
+      "tag": "0010_fine_dagger",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/app/pages/SessionPage.tsx
+++ b/frontend/app/pages/SessionPage.tsx
@@ -1,3 +1,5 @@
+import { ActiveSessionControl } from '@/components/capture/ActiveSessionControl'
+import { UnconfirmedRoundsTable } from '@/components/capture/UnconfirmedRoundsTable'
 import ConfirmationButton from '@/components/ConfirmationButton'
 import { PageSubheader } from '@/components/PageHeader'
 import SessionCard from '@/components/session/SessionCard'
@@ -331,6 +333,13 @@ export default function SessionPage() {
       />
 
       <TournamentList sessionId={session.id} />
+
+      {canEdit && (
+        <div className='flex flex-col gap-4'>
+          <ActiveSessionControl sessionId={session.id} />
+          <UnconfirmedRoundsTable sessionId={session.id} />
+        </div>
+      )}
 
       {tracks.map(track => (
         <TrackLeaderboard

--- a/frontend/components/capture/ActiveSessionControl.tsx
+++ b/frontend/components/capture/ActiveSessionControl.tsx
@@ -1,0 +1,34 @@
+import { toast } from 'sonner'
+import { useConnection } from '@/contexts/ConnectionContext'
+import { useData } from '@/contexts/DataContext'
+import loc from '@/lib/locales'
+import { Button } from '@/components/ui/button'
+
+export function ActiveSessionControl({ sessionId }: { sessionId: string }) {
+  const { socket } = useConnection()
+  const { captureState } = useData()
+  const isActive = captureState.activeSessionId === sessionId
+
+  function setActive(active: boolean) {
+    toast.promise(
+      socket
+        .emitWithAck('set_active_session', {
+          type: 'SetActiveSessionRequest',
+          sessionId: active ? sessionId : null,
+        })
+        .then(r => {
+          if (!r.success) throw new Error(r.message)
+        }),
+      loc.no.capture.activateRequest,
+    )
+  }
+
+  return (
+    <Button
+      variant={isActive ? 'default' : 'outline'}
+      onClick={() => setActive(!isActive)}
+    >
+      {isActive ? loc.no.capture.deactivate : loc.no.capture.activate}
+    </Button>
+  )
+}

--- a/frontend/components/capture/ConfirmRoundDialog.tsx
+++ b/frontend/components/capture/ConfirmRoundDialog.tsx
@@ -1,0 +1,135 @@
+import type {
+  CaptureAssignment,
+  UnconfirmedRound,
+} from '@common/models/capture'
+import { formatTime } from '@common/utils/time'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { useConnection } from '@/contexts/ConnectionContext'
+import { useData } from '@/contexts/DataContext'
+import loc from '@/lib/locales'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { NativeSelect } from '@/components/ui/native-select'
+import { Button } from '@/components/ui/button'
+
+type Props = {
+  round: UnconfirmedRound | null
+  onClose: () => void
+}
+
+export function ConfirmRoundDialog({ round, onClose }: Props) {
+  const { socket } = useConnection()
+  const { users, tracks } = useData()
+  const [picks, setPicks] = useState<Record<number, string>>({})
+
+  if (!round) return null
+
+  const track = tracks.find(t => t.id === round.track)
+  const sortedLaps = [...round.laps].sort((a, b) => a.slot - b.slot)
+
+  function setPick(slot: number, user: string) {
+    setPicks(prev => ({ ...prev, [slot]: user }))
+  }
+
+  function swap() {
+    if (sortedLaps.length !== 2) return
+    const [s1, s2] = sortedLaps
+    setPicks(prev => ({
+      ...prev,
+      [s1.slot]: prev[s2.slot] ?? '',
+      [s2.slot]: prev[s1.slot] ?? '',
+    }))
+  }
+
+  function confirm() {
+    const assignments: CaptureAssignment[] = sortedLaps.map(l => ({
+      slot: l.slot,
+      user: picks[l.slot],
+    }))
+    toast.promise(
+      socket
+        .emitWithAck('confirm_capture', {
+          type: 'ConfirmCaptureRequest',
+          heatId: round.heatId,
+          assignments,
+        })
+        .then(r => {
+          if (!r.success) throw new Error(r.message)
+        }),
+      loc.no.capture.confirmRequest,
+    )
+    onClose()
+  }
+
+  function discard() {
+    toast.promise(
+      socket
+        .emitWithAck('discard_capture', {
+          type: 'DiscardCaptureRequest',
+          heatId: round.heatId,
+        })
+        .then(r => {
+          if (!r.success) throw new Error(r.message)
+        }),
+      loc.no.capture.discardRequest,
+    )
+    onClose()
+  }
+
+  return (
+    <Dialog open={!!round} onOpenChange={o => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{loc.no.capture.assignTitle}</DialogTitle>
+        </DialogHeader>
+        <p className='text-muted-foreground text-sm'>
+          {track?.name ?? track?.mapUid}
+        </p>
+        <div className='flex flex-col gap-3'>
+          {sortedLaps.map(lap => (
+            <div
+              key={lap.slot}
+              className='flex items-center justify-between gap-3'
+            >
+              <span className='font-mono tabular-nums'>
+                {formatTime(lap.duration)}
+              </span>
+              <NativeSelect
+                value={picks[lap.slot] ?? ''}
+                onChange={e => setPick(lap.slot, e.target.value)}
+              >
+                <option value='' disabled>
+                  {loc.no.capture.selectPlayer}
+                </option>
+                {users.map(u => (
+                  <option key={u.id} value={u.id}>
+                    {u.firstName} {u.lastName ?? ''}
+                  </option>
+                ))}
+              </NativeSelect>
+            </div>
+          ))}
+        </div>
+        <DialogFooter className='flex-row justify-between'>
+          <Button variant='ghost' onClick={discard}>
+            {loc.no.capture.discard}
+          </Button>
+          <div className='flex gap-2'>
+            {sortedLaps.length === 2 && (
+              <Button variant='outline' onClick={swap}>
+                {loc.no.capture.swap}
+              </Button>
+            )}
+            <Button onClick={confirm}>{loc.no.capture.confirm}</Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/components/capture/UnconfirmedRoundsTable.tsx
+++ b/frontend/components/capture/UnconfirmedRoundsTable.tsx
@@ -1,0 +1,46 @@
+import type { UnconfirmedRound } from '@common/models/capture'
+import { formatTime } from '@common/utils/time'
+import { useState } from 'react'
+import { useData } from '@/contexts/DataContext'
+import loc from '@/lib/locales'
+import { ConfirmRoundDialog } from './ConfirmRoundDialog'
+
+export function UnconfirmedRoundsTable({ sessionId }: { sessionId: string }) {
+  const { unconfirmedRounds, tracks } = useData()
+  const [selected, setSelected] = useState<UnconfirmedRound | null>(null)
+
+  const rounds = unconfirmedRounds.filter(r => r.session === sessionId)
+  if (rounds.length === 0) return null
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <h3 className='text-muted-foreground text-sm font-semibold uppercase'>
+        {loc.no.capture.unconfirmedTitle}
+      </h3>
+      <div className='bg-background-secondary flex flex-col rounded-sm opacity-60'>
+        {rounds.flatMap(round =>
+          [...round.laps]
+            .sort((a, b) => a.slot - b.slot)
+            .map(lap => {
+              const track = tracks.find(t => t.id === round.track)
+              return (
+                <button
+                  key={`${round.heatId}-${lap.slot}`}
+                  onClick={() => setSelected(round)}
+                  className='flex items-center justify-between px-4 py-3 text-left hover:opacity-100'
+                >
+                  <span className='text-muted-foreground'>
+                    {track?.name ?? track?.mapUid}
+                  </span>
+                  <span className='font-mono tabular-nums'>
+                    {formatTime(lap.duration)}
+                  </span>
+                </button>
+              )
+            }),
+        )}
+      </div>
+      <ConfirmRoundDialog round={selected} onClose={() => setSelected(null)} />
+    </div>
+  )
+}

--- a/frontend/components/capture/UnconfirmedRoundsTable.tsx
+++ b/frontend/components/capture/UnconfirmedRoundsTable.tsx
@@ -40,7 +40,11 @@ export function UnconfirmedRoundsTable({ sessionId }: { sessionId: string }) {
             }),
         )}
       </div>
-      <ConfirmRoundDialog round={selected} onClose={() => setSelected(null)} />
+      <ConfirmRoundDialog
+        key={selected?.heatId ?? 'none'}
+        round={selected}
+        onClose={() => setSelected(null)}
+      />
     </div>
   )
 }

--- a/frontend/contexts/DataContext.tsx
+++ b/frontend/contexts/DataContext.tsx
@@ -1,4 +1,5 @@
 import type { Match } from '@common/models/match'
+import type { CaptureState, UnconfirmedRound } from '@common/models/capture'
 import type { Ranking } from '@common/models/ranking'
 import type { SessionWithSignups } from '@common/models/session'
 import type { TimeEntry } from '@common/models/timeEntry'
@@ -25,6 +26,8 @@ type DataContextType =
       matches: Match[]
       rankings: Ranking[]
       tournaments: TournamentWithDetails[]
+      unconfirmedRounds: UnconfirmedRound[]
+      captureState: CaptureState
     }
   | {
       isLoadingData: true
@@ -35,6 +38,8 @@ type DataContextType =
       matches?: never
       rankings?: never
       tournaments?: never
+      unconfirmedRounds?: never
+      captureState?: never
     }
 
 const DataContext = createContext<DataContextType | undefined>(undefined)
@@ -81,6 +86,8 @@ export function DataProvider({ children }: Readonly<{ children: ReactNode }>) {
     useState<DataContextType['rankings']>(undefined)
   const [tournaments, setTournaments] =
     useState<DataContextType['tournaments']>(undefined)
+  const [unconfirmedRounds, setUnconfirmedRounds] = useState<UnconfirmedRound[]>([])
+  const [captureState, setCaptureState] = useState<CaptureState>({ activeSessionId: null })
 
   useEffect(() => {
     socket.on('all_sessions', data => {
@@ -111,6 +118,9 @@ export function DataProvider({ children }: Readonly<{ children: ReactNode }>) {
       setTournaments(parseDatesArray(data))
     })
 
+    socket.on('all_unconfirmed_rounds', data => { setUnconfirmedRounds(parseDatesArray(data)) })
+    socket.on('capture_state', data => { setCaptureState(data) })
+
     return () => {
       socket.off('all_sessions')
       socket.off('all_time_entries')
@@ -119,6 +129,8 @@ export function DataProvider({ children }: Readonly<{ children: ReactNode }>) {
       socket.off('all_matches')
       socket.off('all_rankings')
       socket.off('all_tournaments')
+      socket.off('all_unconfirmed_rounds')
+      socket.off('capture_state')
     }
   }, [])
 
@@ -143,8 +155,10 @@ export function DataProvider({ children }: Readonly<{ children: ReactNode }>) {
       matches,
       rankings,
       tournaments,
+      unconfirmedRounds,
+      captureState,
     }
-  }, [tracks, timeEntries, users, sessions, matches, rankings, tournaments])
+  }, [tracks, timeEntries, users, sessions, matches, rankings, tournaments, unconfirmedRounds, captureState])
 
   return <DataContext.Provider value={context}>{children}</DataContext.Provider>
 }

--- a/frontend/lib/locales.ts
+++ b/frontend/lib/locales.ts
@@ -48,6 +48,7 @@ const no = {
       groups: 'Grupper',
       groupPlayers: 'Gruppespillere',
       tournamentMatches: 'Turneringsmatcher',
+      unconfirmedLaps: 'Ubekrefta runder',
     } satisfies Record<ExportCsvRequest['table'], string>,
   },
   user: {

--- a/frontend/lib/locales.ts
+++ b/frontend/lib/locales.ts
@@ -407,6 +407,32 @@ const no = {
       },
     },
   },
+  capture: {
+    unconfirmedTitle: 'Ubekrefta runder',
+    activate: 'Aktiver registrering',
+    deactivate: 'Stopp registrering',
+    active: 'Registrering aktiv',
+    assignTitle: 'Hvem kjørte?',
+    selectPlayer: 'Velg spiller',
+    swap: 'Bytt om',
+    confirm: 'Bekreft',
+    discard: 'Forkast',
+    confirmRequest: {
+      loading: 'Bekrefter runde...',
+      success: 'Runde registrert',
+      error: (err: Error) => `Feil ved registrering: ${err.message}`,
+    },
+    discardRequest: {
+      loading: 'Forkaster runde...',
+      success: 'Runde forkastet',
+      error: (err: Error) => `Feil ved forkasting: ${err.message}`,
+    },
+    activateRequest: {
+      loading: 'Endrer registrering...',
+      success: 'Registrering oppdatert',
+      error: (err: Error) => `Feil: ${err.message}`,
+    },
+  },
   tracks: {
     title: 'Baner',
     description: 'Oversikt over banetider per bane.',

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "npm run db:migrate && node dist/server/server.js",
     "dev": "tsx watch --env-file .env backend/src/server.ts",
     "check": "drizzle-kit check && tsc --noEmit && prettier -c .",
+    "test": "tsx --test \"backend/**/*.spec.ts\"",
     "build": "npm run build:frontend && npm run build:backend",
     "build:frontend": "vite build",
     "build:backend": "tsup backend/src/server.ts --format esm --target node20 --out-dir dist/server --clean",

--- a/scripts/mock-plugin.ts
+++ b/scripts/mock-plugin.ts
@@ -1,0 +1,27 @@
+const url = process.env.CAPTURE_URL ?? 'http://localhost:6996/api/capture/heat'
+const token = process.env.CAPTURE_TOKEN ?? ''
+const playerCount = Number(process.argv[2] ?? '2')
+
+const results =
+  playerCount === 1
+    ? [{ slot: 1, bestTimeMs: 41000 }]
+    : [
+        { slot: 1, bestTimeMs: 42300 },
+        { slot: 2, bestTimeMs: 45100 },
+      ]
+
+const body = {
+  contractVersion: 1,
+  heatId: `mock-${Date.now()}`,
+  mapUid: 'mock-map-uid',
+  mapName: 'Mock Map',
+  playerCount,
+  results,
+}
+
+const res = await fetch(url, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+  body: JSON.stringify(body),
+})
+console.log(res.status, await res.json())


### PR DESCRIPTION
## Overview

Adds automatic capture of Trackmania 2020 finish times, running **in parallel with** the existing manual entry. A separate Openplanet plugin (its own repo) POSTs finished-heat results to a new endpoint; while a session is marked "active for capture", the times appear as faded **Ubekrefta runder** rows at the top of that session for an admin/moderator to assign to player(s) and confirm.

This is the **backend + UI** side only. The Openplanet plugin is a separate repository and is not part of this PR.

## What's included

- **Ingest endpoint** `POST /api/capture/heat` — Bearer-token auth via a new `CAPTURE_TOKEN` env var (503 when unset, 401 on mismatch). Heats received with no active session are logged and ignored; heats with an unsupported player count or wrong contract version are discarded.
- **Schema** (migration `0010`): new `unconfirmed_laps` table; `time_entries.source` (`'manual' | 'auto'`, default `'manual'`); TM2020 map identity on `tracks` (`map_uid`/`name`/`author`), with the Turbo `number`/`level`/`type` columns relaxed to nullable so existing data is untouched.
- **CaptureManager** — in-memory active-session state, ingest, and confirm/discard handlers wired over Socket.IO, reusing the existing reactive broadcast pattern (`all_unconfirmed_rounds`, `all_time_entries`, `all_matches`, `all_rankings`). All mutations are gated to admin/moderator.
- **UI** — a faded "Ubekrefta runder" table on the session page (admin/mod only); clicking a row opens an assign dialog (solo = 1 dropdown, 1v1 = 2 dropdowns + Swap). Time and map are automatic; only the player(s) are picked. Confirm writes `time_entries` (`source='auto'`) and, for 1v1, a completed `matches` row (winner = faster slot).
- CSV import/export updated for the new table; README + a versioned HTTP contract doc.

## Testing

- **17 backend tests** (`npm test`, node:test via tsx): payload validation, winner derivation, idempotency by `heatId`, confirm/discard, solo vs 1v1, no-active-session ignore, unsupported-heat discard, track auto-create.
- **Full socket + HTTP round-trip verified end-to-end** on a seeded DB: set active session -> ingest stores -> confirm writes two `auto` entries + a completed match with the correct winner -> solo writes one entry, no match -> discard removes laps without writing.
- `tsc --noEmit` clean; `vite build` passes. Migration `0010` is safe on a populated DB (the `tracks` rebuild copies only pre-existing columns; `source` carries a SQL default).

## Notes for review

- Design spec: `docs/superpowers/specs/2026-06-08-trackmania-autocapture-design.md`; contract: `docs/autocapture/capture-contract.md`.
- Spotted but **not** fixed here (pre-existing, unrelated): `TrackManager.getAllTracks()` throws on an empty `tracks` table, which crashes the server on socket connect with a fresh DB. Happy to fix in a separate PR.