### PR TITLE
Switch dev server off vite-express and set Vite WS port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-SECRET="<secret>"
-PORT="6996"
-VITE_ALLOW_SIGNUPS="false"
+SECRET=<secret>
+PORT=6996
+VITE_ALLOW_SIGNUPS=false

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -30,19 +30,6 @@ const ORIGIN = new URL(process.env.ORIGIN ?? `http://localhost:${PORT}`)
 const app = express()
 const server = createServer(app)
 
-if (!isProduction) {
-  const { createServer: createViteServer } = await import('vite')
-  const vite = await createViteServer({ server: { middlewareMode: true } })
-  app.use(vite.middlewares)
-  server.on('close', () => void vite.close())
-} else {
-  app.use(express.static('dist'))
-}
-
-server.listen(PORT, () => {
-  console.log(`Hosted at ${ORIGIN.toString()}`)
-})
-
 const io = new Server<
   ClientToServerEvents,
   ServerToClientEvents,
@@ -104,11 +91,21 @@ app.get('/api/ping', (_req, res) => {
   res.send(pong)
 })
 
-if (isProduction) {
+if (!isProduction) {
+  const { createServer: createViteServer } = await import('vite')
+  const vite = await createViteServer({ server: { middlewareMode: true } })
+  app.use(vite.middlewares)
+  server.on('close', () => void vite.close())
+} else {
+  app.use(express.static('dist'))
   app.get('*splat', (_req, res) =>
     res.sendFile(path.resolve('dist/index.html'))
   )
 }
+
+server.listen(PORT, () => {
+  console.log(`Hosted at ${ORIGIN.toString()}`)
+})
 
 io.on('connect', s => Connect(s))
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,8 +8,9 @@ import type {
   SocketData,
 } from '@common/models/socket.io'
 import express from 'express'
+import { createServer } from 'node:http'
+import path from 'node:path'
 import { Server, Socket } from 'socket.io'
-import ViteExpress from 'vite-express'
 import AdminManager from './managers/admin.manager'
 import ApiManager from './managers/api.manager'
 import AuthManager from './managers/auth.manager'
@@ -22,14 +23,26 @@ import TournamentManager from './managers/tournament.manager'
 import TrackManager from './managers/track.manager'
 import UserManager from './managers/user.manager'
 
+const isProduction = process.env.NODE_ENV === 'production'
 const PORT = process.env.PORT ? Number.parseInt(process.env.PORT) : 6996
 const ORIGIN = new URL(process.env.ORIGIN ?? `http://localhost:${PORT}`)
 
 const app = express()
-const server = ViteExpress.listen(app, PORT)
-server.on('listening', () => {
+const server = createServer(app)
+
+if (!isProduction) {
+  const { createServer: createViteServer } = await import('vite')
+  const vite = await createViteServer({ server: { middlewareMode: true } })
+  app.use(vite.middlewares)
+  server.on('close', () => void vite.close())
+} else {
+  app.use(express.static('dist'))
+}
+
+server.listen(PORT, () => {
   console.log(`Hosted at ${ORIGIN.toString()}`)
 })
+
 const io = new Server<
   ClientToServerEvents,
   ServerToClientEvents,
@@ -90,6 +103,12 @@ app.get('/api/ping', (_req, res) => {
   console.log(`Received ping, responding with '${pong}'`)
   res.send(pong)
 })
+
+if (isProduction) {
+  app.get('*splat', (_req, res) =>
+    res.sendFile(path.resolve('dist/index.html'))
+  )
+}
 
 io.on('connect', s => Connect(s))
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -88,13 +88,6 @@ export default defineConfig([
     },
   },
   {
-    // Ignore vite-express import issue
-    files: ['./backend/src/server.ts'],
-    rules: {
-      'import/default': 'off',
-    },
-  },
-  {
     files: ['./common/**/*.{ts,tsx}'],
     rules: {
       '@typescript-eslint/no-restricted-imports': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,8 +42,7 @@
         "socket.io-client": "^4.8.3",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
-        "vaul": "^1.1.2",
-        "vite-express": "^0.22.1"
+        "vaul": "^1.1.2"
       },
       "devDependencies": {
         "@babel/core": "^8.0.1",
@@ -5622,16 +5621,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7349,79 +7338,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-static-gzip": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/express-static-gzip/-/express-static-gzip-2.2.0.tgz",
-      "integrity": "sha512-4ZQ0pHX0CAauxmzry2/8XFLM6aZA4NBvg9QezSlsEO1zLnl7vMFa48/WIcjzdfOiEUS4S1npPPKP2NHHYAp6qg==",
-      "license": "MIT",
-      "dependencies": {
-        "parseurl": "^1.3.3",
-        "serve-static": "^1.16.2"
-      }
-    },
-    "node_modules/express-static-gzip/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express-static-gzip/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/express-static-gzip/node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express-static-gzip/node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/express-static-gzip/node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9108,18 +9024,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -9627,6 +9531,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -12256,16 +12161,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-express": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/vite-express/-/vite-express-0.22.1.tgz",
-      "integrity": "sha512-hG8nPztZWc4B0lZDspJz5eBHFrHH6c0YJ1RBvkU02uPPA8v+T2Ynj/nEHtZoEbk64fexkTYwwtI8NfRlXu7j7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "express-static-gzip": "^2.2.0",
-        "picocolors": "^1.1.1"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "backend/src/server.ts",
   "scripts": {
-    "start": "node dist/server/server.js",
+    "start": "NODE_ENV=production node dist/server/server.js",
     "dev": "tsx watch --env-file .env backend/src/server.ts",
     "check": "node scripts/check.js",
     "fix": "eslint . --cache --fix && prettier -w .",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "socket.io-client": "^4.8.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "vaul": "^1.1.2",
-    "vite-express": "^0.22.1"
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@babel/core": "^8.0.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import path from 'node:path'
 import { defineConfig } from 'vite'
 
-const port = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 6996
+const port = process.env.PORT ? Number.parseInt(process.env.PORT) : 6996
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,8 @@ import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import path from 'node:path'
 import { defineConfig } from 'vite'
 
+const port = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 6996
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -15,6 +17,12 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './frontend'),
       '@common': path.resolve(__dirname, './common'),
+    },
+  },
+  server: {
+    ws: {
+      clientPort: port + 1,
+      port: port + 1,
     },
   },
 })


### PR DESCRIPTION
## Summary

- Replace `vite-express` with a plain Express + Vite middleware setup in the backend server.
- Serve the built frontend statically in production and keep SPA fallback routing for client-side navigation.
- Configure the Vite dev server WebSocket client/server port to avoid port conflicts with the app server.
- Remove the unused `vite-express` dependency and the related ESLint override.

## Testing

- Not run (not requested)